### PR TITLE
implement snaplock

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -159,5 +159,5 @@ flowchart TD
     controller.Controller .->|queries| radar.Radar 
     controller.Controller -->|brevity responses| composer.Composer
     controller.Controller -->|brevity calls| composer.Composer
-    composer.Composer -->|natural language| synthesizer.Speaker -->|audio| simpleradio.Client
+    composer.Composer -->|natural language| speakers.Speaker -->|audio| simpleradio.Client
 ```

--- a/docs/PLAYER.md
+++ b/docs/PLAYER.md
@@ -40,7 +40,7 @@ Your callsign should be unique within a server. If multiple players have the sam
 
 Avoid:
 
-* Names that are hard to distinguish, like "Spare"/"Spear"
+* Names that are hard to distinguish, like "Spare"/"Spear", "Jester"/"Gesture", "Witch"/"Which"
 * Names that aren't widely recognized words in common parlance, like "Razgriz"
 * Names in poor taste
 
@@ -213,7 +213,22 @@ Tips:
 
 ### SNAPLOCK
 
-🚧 NOT YET IMPLEMENTED 🚧
+Keyword: `SNAPLOCK`
+
+Function: This is a faster form of DECLARE intended for use during a BVR timeline. You tell the GCI the BRA (bearing, range, altitude) of a threat on your radar scope. The GCI will look for a group in that area and response with information.
+
+Arguments:
+
+1. Bearing from you to the contact (required)
+2. Range from you to the contact (required)
+3. Altitude of the contact (required)
+
+Examples:
+
+```
+MOBIUS 1: "Thunderhead Mobius One, snaplock one two five, ten, eight thousand"
+THUNDERHEAD: "Mobius 1, threat group BRAA 125/10, 8000, hot, hostile, two contacts, Flanker."
+```
 
 ### SPIKED
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/ebitengine/oto/v3 v3.1.0
 	github.com/gammazero/deque v0.2.1
 	github.com/ggerganov/whisper.cpp/bindings/go v0.0.0-20240727173504-6739eb83c3ca
+	github.com/hbollon/go-edlib v1.6.0
 	github.com/lithammer/shortuuid/v3 v3.0.7
 	github.com/martinlindhe/unit v0.0.0-20230420213220-4adfd7d0a0d6
 	github.com/paulmach/orb v0.11.1

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
 github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hbollon/go-edlib v1.6.0 h1:ga7AwwVIvP8mHm9GsPueC0d71cfRU/52hmPJ7Tprv4E=
+github.com/hbollon/go-edlib v1.6.0/go.mod h1:wnt6o6EIVEzUfgbUZY7BerzQ2uvzp354qmS2xaLkrhM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=

--- a/pkg/brevity/snaplock.go
+++ b/pkg/brevity/snaplock.go
@@ -15,8 +15,8 @@ type SnaplockRequest struct {
 type SnaplockResponse struct {
 	// Callsign of the friendly aircraft requesting the SNAPLOCK.
 	Callsign string
-	// Status is true if the SNAPLOCK was correlated to a group, otherwise false.
-	Status bool
-	// Group that was identified. If Status is false, this may be nil.
+	// Declaration of the contact.
+	Declaration Declaration
+	// Group that was identified. If Declaration is Unable or Furball, this may be nil.
 	Group Group
 }

--- a/pkg/composer/braa.go
+++ b/pkg/composer/braa.go
@@ -9,28 +9,19 @@ import (
 
 // ComposeBRAA constructs natural language brevity for communicating BRAA information.
 // Example: "BRAA 270/20, 20000, hot"
-func (c *composer) ComposeBRAA(braa brevity.BRAA) NaturalLanguageResponse {
+func (c *composer) ComposeBRAA(braa brevity.BRAA, declaration brevity.Declaration) NaturalLanguageResponse {
 	if !braa.Bearing().IsMagnetic() {
 		log.Error().Any("bearing", braa.Bearing()).Msg("bearing provided to ComposeBRAA should be magnetic")
 	}
+	bearing := PronounceBearing(braa.Bearing())
 	var aspect string
 	if braa.Aspect() != brevity.UnknownAspect {
 		aspect = string(braa.Aspect())
 	}
+	_range := int(braa.Range().NauticalMiles())
+	altitude := c.ComposeAltitude(braa.Altitude(), declaration)
 	return NaturalLanguageResponse{
-		Subtitle: fmt.Sprintf(
-			"BRAA %s/%d, %d, %s",
-			braa.Bearing().String(),
-			int(braa.Range().NauticalMiles()),
-			int(braa.Altitude().Feet()),
-			aspect,
-		),
-		Speech: fmt.Sprintf(
-			"brah %s, %d, %d, %s",
-			PronounceBearing(braa.Bearing()),
-			int(braa.Range().NauticalMiles()),
-			int(braa.Altitude().Feet()),
-			aspect,
-		),
+		Subtitle: fmt.Sprintf("BRAA %s/%d, %s, %s", bearing, _range, altitude, aspect),
+		Speech:   fmt.Sprintf("brah %s, %d, %s, %s", bearing, _range, altitude, aspect),
 	}
 }

--- a/pkg/composer/snaplock.go
+++ b/pkg/composer/snaplock.go
@@ -2,54 +2,21 @@ package composer
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/dharmab/skyeye/pkg/brevity"
 )
 
 // ComposeSnaplockResponse implements [Composer.ComposeSnaplockResponse].
 func (c *composer) ComposeSnaplockResponse(response brevity.SnaplockResponse) NaturalLanguageResponse {
-	isLocationMissing := response.Group.BRAA() == nil
-	isDeclarationUnable := response.Group.Declaration() == brevity.Unable
-	isDeclarationFurball := response.Group.Declaration() == brevity.Furball
-	if isLocationMissing || isDeclarationUnable || isDeclarationFurball {
-		reply := fmt.Sprintf("%s, %s", response.Callsign, brevity.Unable)
+	if response.Declaration == brevity.Hostile || response.Declaration == brevity.Friendly {
+		info := c.ComposeCoreInformationFormat(response.Group)
 		return NaturalLanguageResponse{
-			Subtitle: reply,
-			Speech:   reply,
+			Subtitle: fmt.Sprintf("%s, %s", response.Callsign, info.Subtitle),
+			Speech:   fmt.Sprintf("%s, %s", response.Callsign, info.Speech),
 		}
 	}
 
-	if response.Status {
-		var subtitleBuilder strings.Builder
-		var speechBuilder strings.Builder
-		braa := c.ComposeBRAA(response.Group.BRAA())
-		contacts := c.ComposeContacts(response.Group.Contacts())
-		subtitleBuilder.WriteString(fmt.Sprintf(
-			"%s, %s, %s",
-			response.Callsign,
-			braa.Subtitle,
-			response.Group.Declaration(),
-		))
-		speechBuilder.WriteString(fmt.Sprintf(
-			"%s, %s, %s",
-			response.Callsign,
-			braa.Speech,
-			response.Group.Declaration(),
-		))
-		if contacts.Subtitle != "" {
-			subtitleBuilder.WriteString(fmt.Sprintf(", %s", contacts.Subtitle))
-		}
-		if contacts.Speech != "" {
-			speechBuilder.WriteString(fmt.Sprintf(", %s", contacts.Speech))
-		}
-		return NaturalLanguageResponse{
-			Subtitle: "Threat group %s, %s",
-			Speech:   "SNAP LOCK",
-		}
-	}
-
-	reply := fmt.Sprintf("%s, %s", response.Callsign, brevity.Clean)
+	reply := fmt.Sprintf("%s, %s", response.Callsign, response.Declaration)
 	return NaturalLanguageResponse{
 		Subtitle: reply,
 		Speech:   reply,

--- a/pkg/controller/alphacheck.go
+++ b/pkg/controller/alphacheck.go
@@ -9,7 +9,7 @@ import (
 func (c *controller) HandleAlphaCheck(request *brevity.AlphaCheckRequest) {
 	logger := log.With().Str("callsign", request.Callsign).Type("type", request).Logger()
 	logger.Debug().Msg("handling request")
-	trackfile := c.findCallsign(request.Callsign)
+	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign)
 	if trackfile == nil {
 		logger.Debug().Msg("no trackfile found for requestor")
 		c.out <- brevity.AlphaCheckResponse{
@@ -21,7 +21,7 @@ func (c *controller) HandleAlphaCheck(request *brevity.AlphaCheckRequest) {
 	logger.Debug().Msg("found requestor's trackfile")
 	location := trackfile.Bullseye(c.scope.GetBullseye())
 	c.out <- brevity.AlphaCheckResponse{
-		Callsign: request.Callsign,
+		Callsign: foundCallsign,
 		Status:   true,
 		Location: location,
 	}

--- a/pkg/controller/bogeydope.go
+++ b/pkg/controller/bogeydope.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"github.com/dharmab/skyeye/pkg/brevity"
+	"github.com/martinlindhe/unit"
 	"github.com/rs/zerolog/log"
 )
 
@@ -9,26 +10,39 @@ import (
 func (c *controller) HandleBogeyDope(request *brevity.BogeyDopeRequest) {
 	logger := log.With().Str("callsign", request.Callsign).Type("type", request).Any("filter", request.Filter).Logger()
 	logger.Debug().Msg("handling request")
-	requestorTrackfile := c.findCallsign(request.Callsign)
-	if requestorTrackfile == nil {
+	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign)
+	if trackfile == nil {
 		logger.Info().Msg("no trackfile found for requestor")
 		c.out <- brevity.NegativeRadarContactResponse{Callsign: request.Callsign}
 		return
 	}
-	logger = logger.With().Str("requestorTrackfile", requestorTrackfile.String()).Logger()
-	logger.Info().Msg("found requestor's trackfile")
 
-	requestorLocation := requestorTrackfile.LastKnown().Point
-	nearestGroup := c.scope.FindNearestGroupWithBRAA(requestorLocation, c.hostileCoalition(), request.Filter)
+	logger = logger.With().Str("callsign", foundCallsign).Logger()
+	logger.Info().Str("trackfile", trackfile.String()).Msg("found requestor's trackfile")
+
+	origin := trackfile.LastKnown().Point
+
+	radius := 300 * unit.NauticalMile
+	nearestGroup := c.scope.FindNearestGroupWithBRAA(
+		origin,
+		lowestAltitude,
+		highestAltitude,
+		radius,
+		c.hostileCoalition(),
+		request.Filter,
+	)
+
 	if nearestGroup == nil {
 		logger.Info().Msg("no hostile groups found")
-		c.out <- brevity.BogeyDopeResponse{Callsign: request.Callsign, Group: nil}
+		c.out <- brevity.BogeyDopeResponse{Callsign: foundCallsign, Group: nil}
 		return
 	}
+
 	nearestGroup.SetDeclaration(brevity.Hostile)
+
 	logger.Info().
 		Any("platforms", nearestGroup.Platforms()).
 		Str("aspect", string(nearestGroup.Aspect())).
 		Msg("found nearest hostile group")
-	c.out <- brevity.BogeyDopeResponse{Callsign: request.Callsign, Group: nearestGroup}
+	c.out <- brevity.BogeyDopeResponse{Callsign: foundCallsign, Group: nearestGroup}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -8,11 +8,13 @@ import (
 	"github.com/dharmab/skyeye/pkg/brevity"
 	"github.com/dharmab/skyeye/pkg/coalitions"
 	"github.com/dharmab/skyeye/pkg/radar"
-	"github.com/dharmab/skyeye/pkg/trackfiles"
 	"github.com/martinlindhe/unit"
 	"github.com/paulmach/orb"
 	"github.com/rs/zerolog/log"
 )
+
+var lowestAltitude = unit.Length(0)
+var highestAltitude = unit.Length(100000) * unit.Foot
 
 // Controller handles requests for GCI service.
 type Controller interface {
@@ -83,17 +85,4 @@ func (c *controller) hostileCoalition() coalitions.Coalition {
 		return coalitions.Red
 	}
 	return coalitions.Red
-}
-
-// findCallsign searches the controller's scope for a trackfile matching the given callsign.
-func (c *controller) findCallsign(callsign string) *trackfiles.Trackfile {
-	logger := log.With().Str("callsign", callsign).Logger()
-	logger.Debug().Msg("searching scope for trackfile matching callsign")
-	trackfile := c.scope.FindCallsign(callsign)
-	if trackfile == nil {
-		logger.Debug().Msg("no trackfile found for callsign")
-	} else {
-		logger.Debug().Str("name", trackfile.Contact.Name).Str("aircraft", trackfile.Contact.ACMIName).Int("unitID", int(trackfile.Contact.UnitID)).Msg("trackfile found for callsign")
-	}
-	return trackfile
 }

--- a/pkg/controller/declare.go
+++ b/pkg/controller/declare.go
@@ -16,17 +16,29 @@ func (c *controller) HandleDeclare(request *brevity.DeclareRequest) {
 		logger.Error().Any("bearing", request.Location.Bearing()).Msg("bearing provided to HandleDeclare should be magnetic")
 	}
 
-	location := geo.PointAtBearingAndDistance(
+	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign)
+
+	if trackfile == nil {
+		logger.Info().Msg("no trackfile found for requestor")
+		c.out <- brevity.NegativeRadarContactResponse{Callsign: request.Callsign}
+		return
+	}
+	origin := trackfile.LastKnown().Point
+
+	aoi := geo.PointAtBearingAndDistance(
 		c.scope.GetBullseye(),
 		request.Location.Bearing().True(c.scope.Declination(c.scope.GetBullseye())).Degrees(),
 		request.Location.Distance().Meters(),
 	)
 	radius := 10 * unit.NauticalMile // TODO reduce to 3 when magvar is available
-	friendlyGroups := c.scope.FindNearbyGroups(location, radius, c.coalition, brevity.Aircraft)
-	hostileGroups := c.scope.FindNearbyGroups(location, radius, c.hostileCoalition(), brevity.Aircraft)
+	altitudeMargin := unit.Length(5000) * unit.Foot
+	minAltitude := request.Altitude - altitudeMargin
+	maxAltitude := request.Altitude + altitudeMargin
+	friendlyGroups := c.scope.FindNearbyGroups(origin, aoi, minAltitude, maxAltitude, radius, c.coalition, brevity.Aircraft)
+	hostileGroups := c.scope.FindNearbyGroups(origin, aoi, minAltitude, maxAltitude, radius, c.hostileCoalition(), brevity.Aircraft)
 	logger.Debug().Int("friendly", len(friendlyGroups)).Int("hostile", len(hostileGroups)).Msg("queried groups near delcared location")
 
-	response := brevity.DeclareResponse{Callsign: request.Callsign}
+	response := brevity.DeclareResponse{Callsign: foundCallsign}
 	if len(friendlyGroups)+len(hostileGroups) == 0 {
 		logger.Debug().Msg("no groups found")
 		response.Declaration = brevity.Clean

--- a/pkg/controller/picture.go
+++ b/pkg/controller/picture.go
@@ -10,7 +10,7 @@ func (c *controller) HandlePicture(request *brevity.PictureRequest) {
 	logger := log.With().Str("callsign", request.Callsign).Type("type", request).Logger()
 	logger.Debug().Msg("handling request")
 
-	trackfile := c.scope.FindCallsign(request.Callsign)
+	_, trackfile := c.scope.FindCallsign(request.Callsign)
 	if trackfile == nil {
 		logger.Warn().Msg("callsign not found")
 		c.out <- brevity.NegativeRadarContactResponse{Callsign: request.Callsign}

--- a/pkg/controller/radiocheck.go
+++ b/pkg/controller/radiocheck.go
@@ -9,7 +9,7 @@ import (
 func (c *controller) HandleRadioCheck(request *brevity.RadioCheckRequest) {
 	logger := log.With().Str("callsign", request.Callsign).Type("type", request).Logger()
 	logger.Debug().Msg("handling request")
-	trackfile := c.findCallsign(request.Callsign)
+	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign)
 	status := trackfile != nil
 	if !status {
 		logger.Debug().Msg("no trackfile found for requestor")
@@ -17,5 +17,5 @@ func (c *controller) HandleRadioCheck(request *brevity.RadioCheckRequest) {
 		return
 	}
 	logger.Debug().Msg("found requestor's trackfile")
-	c.out <- brevity.RadioCheckResponse{Callsign: request.Callsign}
+	c.out <- brevity.RadioCheckResponse{Callsign: foundCallsign}
 }

--- a/pkg/controller/snaplock.go
+++ b/pkg/controller/snaplock.go
@@ -2,43 +2,86 @@ package controller
 
 import (
 	"github.com/dharmab/skyeye/pkg/brevity"
+	"github.com/martinlindhe/unit"
 	"github.com/paulmach/orb/geo"
 	"github.com/rs/zerolog/log"
 )
 
 // HandleSnaplock implements Controller.HandleSnaplock.
 func (c *controller) HandleSnaplock(request *brevity.SnaplockRequest) {
-	logger := log.With().Str("callsign", request.Callsign).Type("type", request).Logger()
-	logger.Debug().Msg("handling request")
+	logger := log.With().Str("callsign", request.Callsign).Type("type", request).Any("request", request).Logger()
+
+	logger.
+		Info().
+		Float64("bearing", request.BRA.Bearing().Rounded().Degrees()).
+		Float64("range", request.BRA.Range().NauticalMiles()).
+		Float64("altitude", request.BRA.Altitude().Feet()).
+		Msg("received request")
 
 	if !request.BRA.Bearing().IsMagnetic() {
 		logger.Error().Any("bearing", request.BRA.Bearing()).Msg("bearing provided to HandleSnaplock should be magnetic")
 	}
 
-	requestorTrackfile := c.findCallsign(request.Callsign)
-	if requestorTrackfile == nil {
+	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign)
+	if trackfile == nil {
 		logger.Info().Msg("no trackfile found for requestor")
 		c.out <- brevity.NegativeRadarContactResponse{Callsign: request.Callsign}
 		return
 	}
 
-	origin := requestorTrackfile.LastKnown().Point
-	targetLocation := geo.PointAtBearingAndDistance(
+	origin := trackfile.LastKnown().Point
+	pointOfInterest := geo.PointAtBearingAndDistance(
 		origin,
 		request.BRA.Bearing().True(c.scope.Declination(origin)).Degrees(),
 		request.BRA.Range().Meters(),
 	)
-	group := c.scope.FindNearestGroupWithBullseye(targetLocation, c.hostileCoalition(), brevity.Aircraft)
+	radius := 10 * unit.NauticalMile // TODO reduce to 3 when magvar is available
+	altitudeMargin := unit.Length(5000) * unit.Foot
+	minAltitude := request.BRA.Altitude() - altitudeMargin
+	maxAltitude := request.BRA.Altitude() + altitudeMargin
+	friendlyGroups := c.scope.FindNearbyGroups(
+		origin,
+		pointOfInterest,
+		minAltitude,
+		maxAltitude,
+		radius,
+		c.coalition,
+		brevity.Aircraft,
+	)
+	hostileGroups := c.scope.FindNearbyGroups(
+		origin,
+		pointOfInterest,
+		minAltitude,
+		maxAltitude,
+		radius,
+		c.hostileCoalition(),
+		brevity.Aircraft,
+	)
 
-	status := group != nil
-	if !status {
-		logger.Debug().Msg("no hostile groups found")
-	} else {
-		logger.Debug().Msg("found nearest hostile group")
+	response := brevity.SnaplockResponse{Callsign: foundCallsign}
+
+	// TODO better algorithm for picking from multiple possible groups
+	if len(friendlyGroups)+len(hostileGroups) == 0 {
+		response.Declaration = brevity.Clean
+	} else if len(friendlyGroups) > 0 && len(hostileGroups) == 0 {
+		response.Declaration = brevity.Friendly
+		response.Group = friendlyGroups[0]
+	} else if len(friendlyGroups) == 0 && len(hostileGroups) > 0 {
+		response.Declaration = brevity.Hostile
+		response.Group = hostileGroups[0]
+		for _, group := range hostileGroups {
+			if group.Aspect() == brevity.Hot {
+				response.Group = group
+				break
+			}
+		}
+	} else if len(friendlyGroups) > 0 && len(hostileGroups) > 0 {
+		response.Declaration = brevity.Furball
 	}
-	c.out <- brevity.SnaplockResponse{
-		Callsign: request.Callsign,
-		Status:   status,
-		Group:    group,
+
+	if response.Group != nil {
+		response.Group.SetDeclaration(response.Declaration)
 	}
+
+	c.out <- response
 }

--- a/pkg/encyclopedia/aircraft.go
+++ b/pkg/encyclopedia/aircraft.go
@@ -842,7 +842,7 @@ var aircraftData = append([]Aircraft{
 		OfficialName:        "Fullback",
 	},
 	{
-		ACMIShortName:       "Tornado",
+		ACMIShortName:       "Tornado GR4",
 		tags:                tornadoData.tags,
 		PlatformDesignation: tornadoData.PlatformDesignation,
 		TypeDesignation:     "Tornado",

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -49,6 +49,7 @@ const (
 	radioCheck requestWord = "radio"
 	spike      requestWord = "spike"
 	spiked     requestWord = "spiked"
+	snap       requestWord = "snap"
 	snaplock   requestWord = "snaplock"
 )
 
@@ -67,7 +68,7 @@ var alternateRequestWords = map[string]requestWord{
 }
 
 func requestWords() []requestWord {
-	return []requestWord{alphaCheck, bogeyDope, declare, picture, radioCheck, spiked, spike, snaplock}
+	return []requestWord{alphaCheck, bogeyDope, declare, picture, radioCheck, spiked, spike, snap, snaplock}
 }
 
 func (p *parser) parseWakeWord(scanner *bufio.Scanner) (string, bool) {
@@ -152,7 +153,6 @@ func (p *parser) Parse(tx string) (any, bool) {
 						_ = scanner.Scan()
 						log.Debug().Str("text", tx).Str("request", string(word)).Msg("found request word")
 					}
-					break
 				}
 			}
 		}
@@ -176,6 +176,8 @@ func (p *parser) Parse(tx string) (any, bool) {
 		return p.parseSpiked(callsign, scanner)
 	case spiked:
 		return p.parseSpiked(callsign, scanner)
+	case snap:
+		return p.parseSnaplock(callsign, scanner)
 	case snaplock:
 		return p.parseSnaplock(callsign, scanner)
 	default:
@@ -195,6 +197,7 @@ func (p *parser) sanitize(s string) string {
 
 	s = strings.ReplaceAll(lowercased, ",", "")
 	s = strings.ReplaceAll(s, "-", " ")
+	s = strings.ReplaceAll(s, ".", "")
 
 	punctuationCleaned := sanitizerRex.ReplaceAllString(s, " ")
 	if lowercased != punctuationCleaned {
@@ -251,6 +254,7 @@ var numberWords = map[string]int{
 //
 // Garbage in between the digits is ignored. The result is normalized so that each digit is lowercase and space-delimited.
 func ParseCallsign(tx string) (callsign string, isValid bool) {
+	tx, _, _ = strings.Cut(tx, "|")
 	tx = strings.Trim(tx, " ")
 	for i, char := range tx {
 		if unicode.IsDigit(char) {

--- a/pkg/parser/snaplock_test.go
+++ b/pkg/parser/snaplock_test.go
@@ -23,6 +23,18 @@ func TestParserSnaplock(t *testing.T) {
 			},
 			expectedOk: true,
 		},
+		{
+			text: "Anyface Fox 1 2 snap lock 0-5-8-147-3000",
+			expectedRequest: &brevity.SnaplockRequest{
+				Callsign: "fox 1 2",
+				BRA: brevity.NewBRA(
+					bearings.NewMagneticBearing(58*unit.Degree),
+					147*unit.NauticalMile,
+					3000*unit.Foot,
+				),
+			},
+			expectedOk: true,
+		},
 	}
 	runParserTestCases(t, New(TestCallsign), testCases, func(t *testing.T, test parserTestCase, request any) {
 		expected := test.expectedRequest.(*brevity.SnaplockRequest)

--- a/pkg/radar/group.go
+++ b/pkg/radar/group.go
@@ -98,6 +98,11 @@ func (g *group) Track() brevity.Track {
 	return g.contacts[0].Direction()
 }
 
+func (g *group) course() bearings.Bearing {
+	// TODO interpolate from all members
+	return g.contacts[0].Course()
+}
+
 // Aspect implements [brevity.Group.Aspect]
 func (g *group) Aspect() brevity.Aspect {
 	if g.aspect == nil {
@@ -181,11 +186,11 @@ func (g *group) category() brevity.ContactCategory {
 
 // point returns the center point of the group
 func (g *group) point() orb.Point {
-	points := orb.MultiPoint{}
-	for _, trackfile := range g.contacts {
-		points = append(points, trackfile.LastKnown().Point)
+	center := g.contacts[0].LastKnown().Point
+	for _, trackfile := range g.contacts[1:] {
+		center = geo.Midpoint(center, trackfile.LastKnown().Point)
 	}
-	return points.Bound().Center()
+	return center
 }
 
 // missionTime returns the mission-time timestamp of the most recent trackfile in the group

--- a/pkg/radar/id.go
+++ b/pkg/radar/id.go
@@ -1,40 +1,24 @@
 package radar
 
 import (
-	"time"
-
 	"github.com/dharmab/skyeye/pkg/trackfiles"
 	"github.com/rs/zerolog/log"
 )
 
-func (s *scope) FindCallsign(callsign string) *trackfiles.Trackfile {
-	return find(func() (*trackfiles.Trackfile, bool) {
-		logger := log.With().Str("callsign", callsign).Logger()
-		logger.Debug().Any("contacts", s.contacts).Msg("searching scope for trackfile matching callsign")
-		tf, ok := s.contacts.getByCallsign(callsign)
-		if !ok {
-			return nil, false
-		}
-		return tf, true
-	})
+func (s *scope) FindCallsign(callsign string) (string, *trackfiles.Trackfile) {
+	log.Debug().Str("callsign", callsign).Any("contacts", s.contacts).Msg("searching scope for trackfile matching callsign")
+	foundCallsign, tf, ok := s.contacts.getByCallsign(callsign)
+	if !ok {
+		return callsign, nil
+	}
+	return foundCallsign, tf
 }
 
 func (s *scope) FindUnit(unitId uint32) *trackfiles.Trackfile {
-	return find(func() (*trackfiles.Trackfile, bool) {
-		logger := log.With().Uint32("unitId", unitId).Logger()
-		logger.Debug().Any("contacts", s.contacts).Msg("searching scope for trackfile matching unitId")
-		return s.contacts.getByUnitID(unitId)
-	})
-}
-
-func find(fn func() (*trackfiles.Trackfile, bool)) *trackfiles.Trackfile {
-	tf, ok := fn()
+	log.Debug().Uint32("unitId", unitId).Any("contacts", s.contacts).Msg("searching scope for trackfile matching unitId")
+	trackfile, ok := s.contacts.getByUnitID(unitId)
 	if !ok {
 		return nil
 	}
-	if tf.LastKnown().Timestamp.Before(time.Now().Add(-1 * time.Minute)) {
-		log.Debug().Str("name", tf.Contact.Name).Int("unitId", int(tf.Contact.UnitID)).Dur("age", time.Since(tf.LastKnown().Timestamp)).Msg("trackfile is stale")
-		return nil
-	}
-	return tf
+	return trackfile
 }

--- a/pkg/radar/nearby.go
+++ b/pkg/radar/nearby.go
@@ -1,6 +1,9 @@
 package radar
 
 import (
+	"math"
+
+	"github.com/dharmab/skyeye/pkg/bearings"
 	"github.com/dharmab/skyeye/pkg/brevity"
 	"github.com/dharmab/skyeye/pkg/coalitions"
 	"github.com/martinlindhe/unit"
@@ -8,16 +11,32 @@ import (
 	"github.com/paulmach/orb/geo"
 )
 
-func (s *scope) FindNearbyGroups(location orb.Point, radius unit.Length, coalition coalitions.Coalition, filter brevity.ContactCategory) []brevity.Group {
-	circle := geo.NewBoundAroundPoint(location, float64(radius.Meters()))
+func (s *scope) FindNearbyGroups(origin, interest orb.Point, minAltitude, maxAltitude, radius unit.Length, coalition coalitions.Coalition, filter brevity.ContactCategory) []brevity.Group {
+	circle := geo.NewBoundAroundPoint(interest, float64(radius.Meters()))
 	groups := make([]brevity.Group, 0)
 	itr := s.contacts.itr()
 	for itr.next() {
 		trackfile := itr.value()
-		if s.isMatch(trackfile, coalition, filter) && circle.Contains(trackfile.LastKnown().Point) {
+		isMatch := s.isMatch(trackfile, coalition, filter)
+		inCircle := circle.Contains(trackfile.LastKnown().Point)
+		inStack := minAltitude <= trackfile.LastKnown().Altitude && trackfile.LastKnown().Altitude <= maxAltitude
+		if isMatch && inCircle && inStack {
 			group := s.findGroupForAircraft(trackfile)
+
+			bearing := bearings.NewTrueBearing(
+				unit.Angle(
+					geo.Bearing(origin, group.point()),
+				) * unit.Degree,
+			).Magnetic(s.Declination(origin))
+			_range := unit.Length(math.Abs(geo.Distance(origin, group.point())))
+			altitude := group.Altitude()
+			aspect := brevity.AspectFromAngle(bearing, group.course())
+			group.braa = brevity.NewBRAA(bearing, _range, altitude, aspect)
+			group.bullseye = nil
+
 			groups = append(groups, group)
 		}
 	}
+
 	return groups
 }


### PR DESCRIPTION
Closes #59 

Implement the SNAPLOCK command. To implement this command I had to change the signature of the `Radar.FindNearbyGroups` method, and to keep things consistent I've rewritten the interface so all of the "find" functions have similar arguments.

BONUS FEATURE: Callsign lookups in the contacts database now fall back on fuzzy search if an exact match fails.