### PR TITLE
correct for magnetic declination using contextual time and location

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/lithammer/shortuuid/v3 v3.0.7
 	github.com/martinlindhe/unit v0.0.0-20230420213220-4adfd7d0a0d6
 	github.com/paulmach/orb v0.11.1
+	github.com/proway2/go-igrf v0.5.1
 	github.com/rodaine/numwords v0.0.0-20200910203654-405f4a455f79
 	github.com/rs/zerolog v1.33.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/paulmach/protoscan v0.2.1/go.mod h1:SpcSwydNLrxUGSDvXvO0P7g7AuhJ7lcKf
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/proway2/go-igrf v0.5.1 h1:GLxkN5hHGJHoAVfrkFHgJ8SfKKCTzGWHg3aZweX1lwc=
+github.com/proway2/go-igrf v0.5.1/go.mod h1:nkA3o+7eci3SXLj0nx2yi14e9Td+AAwHFdglavT+oZI=
 github.com/rodaine/numwords v0.0.0-20200910203654-405f4a455f79 h1:0fk+jnjduMBhQ2WNA3BubRESs5HgiqujdpxUUWCqsts=
 github.com/rodaine/numwords v0.0.0-20200910203654-405f4a455f79/go.mod h1:6O99ZbuNiiFpvPTMhvF4natmeT+oFrfSbtbC7LIJwss=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -48,3 +48,5 @@ type Configuration struct {
 var DefaultPictureRadius = encyclopedia.NoLaterThanCommitRange(encyclopedia.SAR2OrAR1) + 50*unit.NauticalMile
 
 const DefaultMarginRadius = 3 * unit.NauticalMile
+
+var InitialTime time.Time = time.Date(1903, time.December, 17, 2, 35, 0, 0, time.UTC) // https://www.nps.gov/articles/firstflight.htm

--- a/pkg/bearings/bearing.go
+++ b/pkg/bearings/bearing.go
@@ -1,60 +1,28 @@
-// package bearings conttains functions for working with absolute and magnetic bearings.
+// package bearings contains functions for working with absolute and magnetic compass bearings.
 package bearings
 
 import (
-	"math"
-	"time"
-
 	"github.com/martinlindhe/unit"
-	"github.com/paulmach/orb"
 )
 
-type Kind int
-
-const (
-	True Kind = iota
-	Magnetic
-)
-
-type Bearing struct {
-	value unit.Angle
-	kind  Kind
-}
-
-func New(kind Kind, value unit.Angle) Bearing {
-	return Bearing{value: Normalize(value), kind: kind}
-}
-
-func (b Bearing) Value() unit.Angle {
-	return b.value
-}
-
-func (b Bearing) Kind() Kind {
-	return b.kind
-}
-
-// Normalize returns the normalized angle in the range (0, 360] degrees, rounded to the nearest degree.
-func Normalize(a unit.Angle) unit.Angle {
-	θ := float64(a.Degrees())
-	for θ < 0 {
-		θ += 360
-	}
-	θ = math.Mod(θ, 360)
-	if θ == 0 {
-		θ = 360
-	}
-	return unit.Angle(θ) * unit.Degree
-}
-
-func Variation(p orb.Point, t time.Time) unit.Angle {
-	// TODO compute from model
-	return unit.Angle(0) * unit.Degree
-}
-
-func TrueToMagnetic(tru unit.Angle, variation unit.Angle) unit.Angle {
-	return Normalize(tru + variation)
-}
-
-func MagneticToTrue(magnetic unit.Angle, variation unit.Angle) unit.Angle {
-	return Normalize(magnetic - variation)
+// Bearing is a compass bearing that can be converted to true or magnetic bearing. Use either True or Magnetic immediately before use to assert which kind is used.
+type Bearing interface {
+	// Value returns the compass heading, normalized in range (0, 360].
+	Value() unit.Angle
+	// Rounded returns the compass heading, normalized in range (0, 360] rounded to the nearest degree.
+	Rounded() unit.Angle
+	// Degrees returns the compass heading in degrees, normalized in range (0, 360].
+	Degrees() float64
+	// RoundedDegrees returns the compass heading in degrees, normalized in range (0, 360] rounded to the nearest degree.
+	RoundedDegrees() float64
+	// True bearing conversion computed with the given declination.
+	True(declination unit.Angle) Bearing
+	// Magnetic bearing conversion computed with the given declination.
+	Magnetic(declination unit.Angle) Bearing
+	// IsTrue returns true if the bearing is a true bearing.
+	IsTrue() bool
+	// IsMagnetic returns true if the bearing is a magnetic bearing.
+	IsMagnetic() bool
+	// String returns the value formatted as a three-digit string.
+	String() string
 }

--- a/pkg/bearings/bearing_test.go
+++ b/pkg/bearings/bearing_test.go
@@ -49,8 +49,47 @@ func TestNormalize(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprint(test.input), func(t *testing.T) {
-			actual := Normalize(unit.Angle(test.input) * unit.Degree).Degrees()
+			actual := normalize(unit.Angle(test.input) * unit.Degree).Degrees()
 			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestBearingToString(t *testing.T) {
+	testCases := []struct {
+		bearing  Bearing
+		expected string
+	}{
+		{
+			bearing:  NewTrueBearing(0 * unit.Degree),
+			expected: "360",
+		},
+		{
+
+			bearing:  NewTrueBearing(1 * unit.Degree),
+			expected: "001",
+		},
+		{
+			bearing:  NewTrueBearing(10 * unit.Degree),
+			expected: "010",
+		},
+		{
+			bearing:  NewTrueBearing(100 * unit.Degree),
+			expected: "100",
+		},
+		{
+			bearing:  NewTrueBearing(359 * unit.Degree),
+			expected: "359",
+		},
+		{
+			bearing:  NewTrueBearing(360 * unit.Degree),
+			expected: "360",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.expected, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.bearing.String())
 		})
 	}
 }

--- a/pkg/bearings/declination.go
+++ b/pkg/bearings/declination.go
@@ -1,0 +1,26 @@
+package bearings
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/martinlindhe/unit"
+	"github.com/paulmach/orb"
+	"github.com/proway2/go-igrf/igrf"
+	"github.com/rs/zerolog/log"
+)
+
+var igrfData = igrf.New()
+
+// Declination returns the magnetic declination at the given point and time.
+func Declination(p orb.Point, t time.Time) (unit.Angle, error) {
+	if t.Year() > 2025 {
+		log.Warn().Msg("clamping date to 2025 for purposes of computing magnetic declination due to IGRF model limits")
+		t = time.Date(2025, t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+	}
+	field, err := igrfData.IGRF(p.Lat(), p.Lon(), 0, float64(t.Year())+float64(t.YearDay())/366)
+	if err != nil {
+		return 0, fmt.Errorf("failed to compute magnetic declination: %w", err)
+	}
+	return normalize(unit.Angle(field.Declination) * unit.Degree), nil
+}

--- a/pkg/bearings/magnetic.go
+++ b/pkg/bearings/magnetic.go
@@ -1,0 +1,64 @@
+package bearings
+
+import (
+	"math"
+
+	"github.com/martinlindhe/unit"
+)
+
+// Magnetic is a magnetic bearing.
+type Magnetic struct {
+	θ unit.Angle
+}
+
+// NewMagneticBearing creates a new magnetic bearing from the given value.
+func NewMagneticBearing(value unit.Angle) *Magnetic {
+	return &Magnetic{θ: normalize(value)}
+}
+
+var _ Bearing = &Magnetic{}
+
+// Value returns the magnetic bearing value.
+func (b *Magnetic) Value() unit.Angle {
+	return normalize(b.θ)
+}
+
+// Rounded returns the magnetic bearing rounded to the nearest degree.
+func (b *Magnetic) Rounded() unit.Angle {
+	return unit.Angle(b.RoundedDegrees()) * unit.Degree
+}
+
+// Degrees returns the magnetic bearing in degrees.
+func (b *Magnetic) Degrees() float64 {
+	return b.Value().Degrees()
+}
+
+// RoundedDegrees returns the magnetic bearing rounded to the nearest degree.
+func (b *Magnetic) RoundedDegrees() float64 {
+	return math.Round(b.Degrees())
+}
+
+// True converts this magnetic bearing to a true bearing by removing the given declination.
+func (b *Magnetic) True(declination unit.Angle) Bearing {
+	return NewTrueBearing(b.Value() + declination)
+}
+
+// Magnetic returns this magnetic bearing.
+func (b *Magnetic) Magnetic(declination unit.Angle) Bearing {
+	return b
+}
+
+// IsTrue returns false for a magnetic bearing.
+func (b *Magnetic) IsTrue() bool {
+	return false
+}
+
+// IsMagnetic returns true for a magnetic bearing.
+func (b *Magnetic) IsMagnetic() bool {
+	return true
+}
+
+// String implements [Bearing.String]
+func (b *Magnetic) String() string {
+	return toString(b)
+}

--- a/pkg/bearings/normalization.go
+++ b/pkg/bearings/normalization.go
@@ -1,0 +1,25 @@
+package bearings
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/martinlindhe/unit"
+)
+
+// normalize returns the normalized angle in the range (0, 360] degrees.
+func normalize(a unit.Angle) unit.Angle {
+	θ := a.Degrees()
+	for θ < 0 {
+		θ += 360
+	}
+	θ = math.Mod(θ, 360)
+	if θ == 0 {
+		θ = 360
+	}
+	return unit.Angle(θ) * unit.Degree
+}
+
+func toString(b Bearing) string {
+	return fmt.Sprintf("%03.0f", b.RoundedDegrees())
+}

--- a/pkg/bearings/true.go
+++ b/pkg/bearings/true.go
@@ -1,0 +1,53 @@
+package bearings
+
+import (
+	"math"
+
+	"github.com/martinlindhe/unit"
+)
+
+type True struct {
+	θ unit.Angle
+}
+
+var _ Bearing = True{}
+
+func NewTrueBearing(value unit.Angle) True {
+	return True{θ: normalize(value)}
+}
+
+func (b True) Value() unit.Angle {
+	return normalize(b.θ)
+}
+
+func (b True) Rounded() unit.Angle {
+	return unit.Angle(b.RoundedDegrees()) * unit.Degree
+}
+
+func (b True) Degrees() float64 {
+	return b.Value().Degrees()
+}
+
+func (b True) RoundedDegrees() float64 {
+	return math.Round(b.Degrees())
+}
+
+func (b True) True(declination unit.Angle) Bearing {
+	return b
+}
+
+func (b True) Magnetic(declination unit.Angle) Bearing {
+	return NewMagneticBearing(b.Value() - declination)
+}
+
+func (b True) IsTrue() bool {
+	return true
+}
+
+func (b True) IsMagnetic() bool {
+	return false
+}
+
+func (b True) String() string {
+	return toString(b)
+}

--- a/pkg/brevity/bullseye.go
+++ b/pkg/brevity/bullseye.go
@@ -3,29 +3,34 @@ package brevity
 import (
 	"math"
 
+	"github.com/dharmab/skyeye/pkg/bearings"
 	"github.com/martinlindhe/unit"
+	"github.com/rs/zerolog/log"
 )
 
 // Bullseye is a magnetic bearing and distance from a reference point called the BULLSEYE.
 // Reference: ATP 3-52.4 Chapter IV section 4 subsection a
 type Bullseye struct {
-	bearingDegrees int
-	distanceNM     int
+	bearing  bearings.Bearing
+	distance unit.Length
 }
 
-func NewBullseye(bearing unit.Angle, distance unit.Length) *Bullseye {
+func NewBullseye(bearing bearings.Bearing, distance unit.Length) *Bullseye {
+	if !bearing.IsMagnetic() {
+		log.Warn().Any("bearing", bearing).Msg("bearing provided to NewBullseye should be magnetic")
+	}
 	return &Bullseye{
-		bearingDegrees: int(math.Round(bearing.Degrees())),
-		distanceNM:     int(math.Round(distance.NauticalMiles())),
+		bearing:  bearing,
+		distance: distance,
 	}
 }
 
 // Bearing from the BULLSEYE to the contact, rounded to the nearest degree.
-func (b *Bullseye) Bearing() unit.Angle {
-	return unit.Angle(b.bearingDegrees) * unit.Degree
+func (b *Bullseye) Bearing() bearings.Bearing {
+	return b.bearing
 }
 
 // Distance from the BULLSEYE to the contact, rounded to the nearest nautical mile.
 func (b *Bullseye) Distance() unit.Length {
-	return unit.Length(b.distanceNM) * unit.NauticalMile
+	return unit.Length(math.Round(b.distance.NauticalMiles())) * unit.NauticalMile
 }

--- a/pkg/brevity/spiked.go
+++ b/pkg/brevity/spiked.go
@@ -1,6 +1,9 @@
 package brevity
 
-import "github.com/martinlindhe/unit"
+import (
+	"github.com/dharmab/skyeye/pkg/bearings"
+	"github.com/martinlindhe/unit"
+)
 
 // SpikedRequest is a request to correlate a radar spike within ±30 degrees.
 // Reference: ATP 3-52.4 Chapter V section 13
@@ -8,7 +11,7 @@ type SpikedRequest struct {
 	// Callsign of the friendly aircraft calling SPIKED.
 	Callsign string
 	// Bearing to the radar spike.
-	Bearing unit.Angle
+	Bearing bearings.Bearing
 }
 
 // SpikedResponse reports any contacts within ±30 degrees of a reported radar spike.
@@ -31,5 +34,5 @@ type SpikedResponse struct {
 	// Number of contacts in the correlated group. If Status is false, this may be zero.
 	Contacts int
 	// Reported spike bearing. This is used if the response did not correlate to a group.
-	Bearing unit.Angle
+	Bearing bearings.Bearing
 }

--- a/pkg/brevity/track.go
+++ b/pkg/brevity/track.go
@@ -1,9 +1,8 @@
 package brevity
 
 import (
-	"math"
-
-	"github.com/martinlindhe/unit"
+	"github.com/dharmab/skyeye/pkg/bearings"
+	"github.com/rs/zerolog/log"
 )
 
 // Track is a compass direction.
@@ -21,29 +20,28 @@ const (
 	Northwest        Track = "northwest"
 )
 
-// TrackFromBearing computes an aircraft's track direction based on the aircraft's heading.
-func TrackFromBearing(bearing unit.Angle) Track {
-	θ := int(math.Round(bearing.Degrees()))
-	for θ < 0 {
-		θ += 360
+// TrackFromBearing computes a track direction based on the given magnetic bearing.
+func TrackFromBearing(bearing bearings.Bearing) Track {
+	if !bearing.IsMagnetic() {
+		log.Warn().Any("bearing", bearing).Msg("bearing provided to TrackFromBearing should be magnetic")
 	}
-	θ = θ % 360
+	θ := bearing.Degrees()
 	switch {
-	case θ > 337 || θ <= 22:
+	case θ >= 337.5 || θ < 22.5:
 		return North
-	case θ > 22 && θ <= 67:
+	case θ < 67.5:
 		return Northeast
-	case θ > 67 && θ <= 112:
+	case θ < 112.5:
 		return East
-	case θ > 112 && θ <= 157:
+	case θ < 157.5:
 		return Southeast
-	case θ > 157 && θ <= 202:
+	case θ < 202.5:
 		return South
-	case θ > 202 && θ <= 247:
+	case θ < 247.5:
 		return Southwest
-	case θ > 247 && θ <= 292:
+	case θ < 292.5:
 		return West
-	case θ > 292 && θ <= 337:
+	case θ < 337.5:
 		return Northwest
 	default:
 		return UnknownDirection

--- a/pkg/composer/alphacheck.go
+++ b/pkg/composer/alphacheck.go
@@ -4,24 +4,28 @@ import (
 	"fmt"
 
 	"github.com/dharmab/skyeye/pkg/brevity"
+	"github.com/rs/zerolog/log"
 )
 
 // ComposeAlphaCheckResponse implements [Composer.ComposeAlphaCheckResponse].
 func (c *composer) ComposeAlphaCheckResponse(response brevity.AlphaCheckResponse) NaturalLanguageResponse {
 	if response.Status {
+		if !response.Location.Bearing().IsMagnetic() {
+			log.Error().Any("bearing", response.Location.Bearing()).Msg("bearing provided to ComposeAlphaCheckResponse should be magnetic")
+		}
 		return NaturalLanguageResponse{
 			Subtitle: fmt.Sprintf(
-				"%s, %s, contact, alpha check bullseye %d/%d",
+				"%s, %s, contact, alpha check bullseye %s/%d",
 				response.Callsign,
 				c.callsign,
-				int(response.Location.Bearing().Degrees()),
+				response.Location.Bearing().String(),
 				int(response.Location.Distance().NauticalMiles()),
 			),
 			Speech: fmt.Sprintf(
 				"%s, %s, contact, alpha check bullseye %s, %d",
 				response.Callsign,
 				c.callsign,
-				PronounceBearing(int(response.Location.Bearing().Degrees())),
+				PronounceBearing(response.Location.Bearing()),
 				int(response.Location.Distance().NauticalMiles()),
 			),
 		}

--- a/pkg/composer/bogeydope.go
+++ b/pkg/composer/bogeydope.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/dharmab/skyeye/pkg/brevity"
+	"github.com/rs/zerolog/log"
 )
 
 // ComposeBogeyDopeResponse implements [Composer.ComposeBogeyDopeResponse].
@@ -14,6 +15,9 @@ func (c *composer) ComposeBogeyDopeResponse(response brevity.BogeyDopeResponse) 
 			Subtitle: reply,
 			Speech:   reply,
 		}
+	}
+	if !response.Group.BRAA().Bearing().IsMagnetic() {
+		log.Error().Any("bearing", response.Group.BRAA().Bearing()).Msg("bearing provided to ComposeBogeyDopeResponse should be magnetic")
 	}
 	info := c.ComposeCoreInformationFormat(response.Group)
 	return NaturalLanguageResponse{

--- a/pkg/composer/braa.go
+++ b/pkg/composer/braa.go
@@ -4,26 +4,30 @@ import (
 	"fmt"
 
 	"github.com/dharmab/skyeye/pkg/brevity"
+	"github.com/rs/zerolog/log"
 )
 
 // ComposeBRAA constructs natural language brevity for communicating BRAA information.
 // Example: "BRAA 270/20, 20000, hot"
 func (c *composer) ComposeBRAA(braa brevity.BRAA) NaturalLanguageResponse {
+	if !braa.Bearing().IsMagnetic() {
+		log.Error().Any("bearing", braa.Bearing()).Msg("bearing provided to ComposeBRAA should be magnetic")
+	}
 	var aspect string
 	if braa.Aspect() != brevity.UnknownAspect {
 		aspect = string(braa.Aspect())
 	}
 	return NaturalLanguageResponse{
 		Subtitle: fmt.Sprintf(
-			"BRAA %d/%d, %d, %s",
-			int(braa.Bearing().Degrees()),
+			"BRAA %s/%d, %d, %s",
+			braa.Bearing().String(),
 			int(braa.Range().NauticalMiles()),
 			int(braa.Altitude().Feet()),
 			aspect,
 		),
 		Speech: fmt.Sprintf(
 			"brah %s, %d, %d, %s",
-			PronounceBearing(int(braa.Bearing().Degrees())),
+			PronounceBearing(braa.Bearing()),
 			int(braa.Range().NauticalMiles()),
 			int(braa.Altitude().Feet()),
 			aspect,

--- a/pkg/composer/bullseye.go
+++ b/pkg/composer/bullseye.go
@@ -4,20 +4,24 @@ import (
 	"fmt"
 
 	"github.com/dharmab/skyeye/pkg/brevity"
+	"github.com/rs/zerolog/log"
 )
 
 // ComposeBullseye constructs natural language brevity for communicating Bullseye information.
 // Example: "bullseye 270/20"
 func (c *composer) ComposeBullseye(bullseye brevity.Bullseye) NaturalLanguageResponse {
+	if !bullseye.Bearing().IsMagnetic() {
+		log.Error().Any("bearing", bullseye.Bearing()).Msg("bearing provided to ComposeBullseye should be magnetic")
+	}
 	return NaturalLanguageResponse{
 		Subtitle: fmt.Sprintf(
-			"bullseye %d/%d",
-			int(bullseye.Bearing().Degrees()),
+			"bullseye %s/%d",
+			bullseye.Bearing().String(),
 			int(bullseye.Distance().NauticalMiles()),
 		),
 		Speech: fmt.Sprintf(
 			"bullseye %s, %d",
-			PronounceBearing(int(bullseye.Bearing().Degrees())),
+			PronounceBearing(bullseye.Bearing()),
 			int(bullseye.Distance().NauticalMiles()),
 		),
 	}

--- a/pkg/composer/format.go
+++ b/pkg/composer/format.go
@@ -7,17 +7,16 @@ import (
 	"unicode"
 
 	"github.com/dharmab/skyeye/pkg/bearings"
-	"github.com/martinlindhe/unit"
 )
 
-// PronounceBearing composes a text representation of a sequence of up to three digits, padded with zeros.
-func PronounceBearing(d int) (s string) {
-	d = int(bearings.Normalize(unit.Angle(d) * unit.Degree).Degrees())
-	s = PronounceInt(d)
-	if d < 10 {
+// PronounceBearing composes a text representation ofbearing.
+func PronounceBearing(bearing bearings.Bearing) (s string) {
+	θ := int(bearing.RoundedDegrees())
+	s = PronounceInt(θ)
+	if θ < 10 {
 		s = "zero " + s
 	}
-	if d < 100 {
+	if θ < 100 {
 		s = "zero " + s
 	}
 	return

--- a/pkg/composer/group.go
+++ b/pkg/composer/group.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/dharmab/skyeye/pkg/brevity"
+	"github.com/rs/zerolog/log"
 )
 
 // ComposeCoreInformationFormat communicates information about groups.
@@ -30,8 +31,13 @@ func (c *composer) ComposeCoreInformationFormat(groups ...brevity.Group) Natural
 }
 
 func (c *composer) ComposeGroup(group brevity.Group) NaturalLanguageResponse {
+	if group.BRAA() != nil && !group.BRAA().Bearing().IsMagnetic() {
+		log.Error().Any("bearing", group.BRAA().Bearing()).Msg("bearing provided to ComposeGroup should be magnetic")
+	}
+	if group.Bullseye() != nil && !group.Bullseye().Bearing().IsMagnetic() {
+		log.Error().Any("bearing", group.Bullseye().Bearing()).Msg("bearing provided to ComposeGroup should be magnetic")
+	}
 	var speech, subtitle strings.Builder
-
 	writeBoth := func(s string) {
 		speech.WriteString(s)
 		subtitle.WriteString(s)

--- a/pkg/composer/spiked.go
+++ b/pkg/composer/spiked.go
@@ -29,6 +29,6 @@ func (c *composer) ComposeSpikedResponse(response brevity.SpikedResponse) Natura
 	}
 	return NaturalLanguageResponse{
 		Subtitle: fmt.Sprintf("%s, %s clean %d.", response.Callsign, c.callsign, int(response.Bearing.Degrees())),
-		Speech:   fmt.Sprintf("%s, %s clean %s", response.Callsign, c.callsign, PronounceBearing(int(response.Bearing.Degrees()))),
+		Speech:   fmt.Sprintf("%s, %s clean %s", response.Callsign, c.callsign, PronounceBearing(response.Bearing)),
 	}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -2,12 +2,14 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	"github.com/dharmab/skyeye/pkg/brevity"
 	"github.com/dharmab/skyeye/pkg/coalitions"
 	"github.com/dharmab/skyeye/pkg/radar"
 	"github.com/dharmab/skyeye/pkg/trackfiles"
 	"github.com/martinlindhe/unit"
+	"github.com/paulmach/orb"
 	"github.com/rs/zerolog/log"
 )
 
@@ -15,6 +17,10 @@ type Controller interface {
 	// Run starts the controller's control loops. It should be called exactly once. It blocks until the context is canceled.
 	// The controller publishes responses to the given channel.
 	Run(context.Context, chan<- any)
+	// SetTime updates the mission time used for computing magnetic declination.
+	SetTime(time.Time)
+	// SetBullseye updates the bullseye point.
+	SetBullseye(orb.Point)
 	// HandleAlphaCheck handles an ALPHA CHECK by reporting the position of the requesting aircraft.
 	HandleAlphaCheck(*brevity.AlphaCheckRequest)
 	// HandleBogeyDope handles a BOGEY DOPE by reporting the closest enemy group to the requesting aircraft.
@@ -57,6 +63,16 @@ func (c *controller) Run(ctx context.Context, out chan<- any) {
 	<-ctx.Done()
 
 	// TODO control loops for FADED and THREAT
+}
+
+// SetTime implements [Controller.SetTime].
+func (c *controller) SetTime(t time.Time) {
+	c.scope.SetMissionTime(t)
+}
+
+// SetBullseye implements [Controller.SetBullseye].
+func (c *controller) SetBullseye(bullseye orb.Point) {
+	c.scope.SetBullseye(bullseye)
 }
 
 // hostileCoalition returns the coalition that is hostile to the controller's coalition.

--- a/pkg/controller/spiked.go
+++ b/pkg/controller/spiked.go
@@ -11,6 +11,10 @@ func (c *controller) HandleSpiked(request *brevity.SpikedRequest) {
 	logger := log.With().Str("callsign", request.Callsign).Type("type", request).Float64("bearing", request.Bearing.Degrees()).Logger()
 	logger.Debug().Msg("handling request")
 
+	if !request.Bearing.IsMagnetic() {
+		logger.Error().Any("bearing", request.Bearing).Msg("bearing provided to HandleSpiked should be magnetic")
+	}
+
 	trackfile := c.scope.FindCallsign(request.Callsign)
 	if trackfile == nil {
 		logger.Info().Msg("no trackfile found for requestor")

--- a/pkg/parser/bogeydope_test.go
+++ b/pkg/parser/bogeydope_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/dharmab/skyeye/pkg/brevity"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParserBogeyDope(t *testing.T) {
@@ -33,5 +34,10 @@ func TestParserBogeyDope(t *testing.T) {
 			expectedOk: true,
 		},
 	}
-	runParserTestCases(t, New(TestCallsign), testCases)
+	runParserTestCases(t, New(TestCallsign), testCases, func(t *testing.T, test parserTestCase, request any) {
+		expected := test.expectedRequest.(*brevity.BogeyDopeRequest)
+		actual := request.(*brevity.BogeyDopeRequest)
+		require.Equal(t, expected.Callsign, actual.Callsign)
+		require.Equal(t, expected.Filter, actual.Filter)
+	})
 }

--- a/pkg/parser/declare_test.go
+++ b/pkg/parser/declare_test.go
@@ -3,8 +3,10 @@ package parser
 import (
 	"testing"
 
+	"github.com/dharmab/skyeye/pkg/bearings"
 	"github.com/dharmab/skyeye/pkg/brevity"
 	"github.com/martinlindhe/unit"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParserDeclare(t *testing.T) {
@@ -14,7 +16,7 @@ func TestParserDeclare(t *testing.T) {
 			expectedRequest: &brevity.DeclareRequest{
 				Callsign: "tater 1 1",
 				Location: *brevity.NewBullseye(
-					54*unit.Degree,
+					bearings.NewMagneticBearing(54*unit.Degree),
 					123*unit.NauticalMile,
 				),
 				Altitude: 3000 * unit.Foot,
@@ -27,7 +29,7 @@ func TestParserDeclare(t *testing.T) {
 			expectedRequest: &brevity.DeclareRequest{
 				Callsign: "fox 1 2",
 				Location: *brevity.NewBullseye(
-					43*unit.Degree,
+					bearings.NewMagneticBearing(43*unit.Degree),
 					102*unit.NauticalMile,
 				),
 				Altitude: 12000 * unit.Foot,
@@ -40,7 +42,7 @@ func TestParserDeclare(t *testing.T) {
 			expectedRequest: &brevity.DeclareRequest{
 				Callsign: "chaos 1 1",
 				Location: *brevity.NewBullseye(
-					76*unit.Degree,
+					bearings.NewMagneticBearing(76*unit.Degree),
 					44*unit.NauticalMile,
 				),
 				Altitude: 3000 * unit.Foot,
@@ -53,7 +55,7 @@ func TestParserDeclare(t *testing.T) {
 			expectedRequest: &brevity.DeclareRequest{
 				Callsign: "dog 1 1",
 				Location: *brevity.NewBullseye(
-					75*unit.Degree,
+					bearings.NewMagneticBearing(75*unit.Degree),
 					26*unit.NauticalMile,
 				),
 				Altitude: 2000 * unit.Foot,
@@ -62,5 +64,13 @@ func TestParserDeclare(t *testing.T) {
 			expectedOk: true,
 		},
 	}
-	runParserTestCases(t, New(TestCallsign), testCases)
+	runParserTestCases(t, New(TestCallsign), testCases, func(t *testing.T, test parserTestCase, request any) {
+		expected := test.expectedRequest.(*brevity.DeclareRequest)
+		actual := request.(*brevity.DeclareRequest)
+		require.Equal(t, expected.Callsign, actual.Callsign)
+		require.InDelta(t, expected.Location.Bearing().Degrees(), actual.Location.Bearing().Degrees(), 0.5)
+		require.InDelta(t, expected.Location.Distance().NauticalMiles(), actual.Location.Distance().NauticalMiles(), 1)
+		require.InDelta(t, expected.Altitude.Feet(), actual.Altitude.Feet(), 50)
+		require.Equal(t, expected.Track, actual.Track)
+	})
 }

--- a/pkg/parser/picture_test.go
+++ b/pkg/parser/picture_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dharmab/skyeye/internal/conf"
 	"github.com/dharmab/skyeye/pkg/brevity"
 	"github.com/martinlindhe/unit"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParserPicture(t *testing.T) {
@@ -27,5 +28,10 @@ func TestParserPicture(t *testing.T) {
 			expectedOk: true,
 		},
 	}
-	runParserTestCases(t, New(TestCallsign), testCases)
+	runParserTestCases(t, New(TestCallsign), testCases, func(t *testing.T, test parserTestCase, request any) {
+		expected := test.expectedRequest.(*brevity.PictureRequest)
+		actual := request.(*brevity.PictureRequest)
+		require.Equal(t, expected.Callsign, actual.Callsign)
+		require.Equal(t, expected.Radius, actual.Radius)
+	})
 }

--- a/pkg/parser/snaplock_test.go
+++ b/pkg/parser/snaplock_test.go
@@ -3,8 +3,10 @@ package parser
 import (
 	"testing"
 
+	"github.com/dharmab/skyeye/pkg/bearings"
 	"github.com/dharmab/skyeye/pkg/brevity"
 	"github.com/martinlindhe/unit"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParserSnaplock(t *testing.T) {
@@ -14,7 +16,7 @@ func TestParserSnaplock(t *testing.T) {
 			expectedRequest: &brevity.SnaplockRequest{
 				Callsign: "freedom 3 1",
 				BRA: brevity.NewBRA(
-					125*unit.Degree,
+					bearings.NewMagneticBearing(125*unit.Degree),
 					10*unit.NauticalMile,
 					8000*unit.Foot,
 				),
@@ -22,5 +24,12 @@ func TestParserSnaplock(t *testing.T) {
 			expectedOk: true,
 		},
 	}
-	runParserTestCases(t, New(TestCallsign), testCases)
+	runParserTestCases(t, New(TestCallsign), testCases, func(t *testing.T, test parserTestCase, request any) {
+		expected := test.expectedRequest.(*brevity.SnaplockRequest)
+		actual := request.(*brevity.SnaplockRequest)
+		require.Equal(t, expected.Callsign, actual.Callsign)
+		require.InDelta(t, expected.BRA.Bearing().Degrees(), actual.BRA.Bearing().Degrees(), 0.5)
+		require.InDelta(t, expected.BRA.Range().NauticalMiles(), actual.BRA.Range().NauticalMiles(), 0.5)
+		require.InDelta(t, expected.BRA.Altitude().Feet(), actual.BRA.Altitude().Feet(), 50)
+	})
 }

--- a/pkg/parser/spatial.go
+++ b/pkg/parser/spatial.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/dharmab/skyeye/pkg/bearings"
 	"github.com/dharmab/skyeye/pkg/brevity"
 	"github.com/martinlindhe/unit"
 	"github.com/rodaine/numwords"
@@ -76,8 +77,8 @@ func (p *parser) parseBRA(scanner *bufio.Scanner) (brevity.BRA, bool) {
 	return brevity.NewBRA(b, r, a), true
 }
 
-// parseBearing parses a 3 digit bearing. Each digit must be individually pronounced. Zeroes must be prefixed to values below 100.
-func (p *parser) parseBearing(scanner *bufio.Scanner) (unit.Angle, bool) {
+// parseBearing parses a 3 digit magnetic bearing. Each digit must be individually pronounced. Zeroes must be prefixed to values below 100.
+func (p *parser) parseBearing(scanner *bufio.Scanner) (bearings.Bearing, bool) {
 	bearing := 0 * unit.Degree
 	digitsParsed := 0
 	for digitsParsed < 3 {
@@ -87,15 +88,15 @@ func (p *parser) parseBearing(scanner *bufio.Scanner) (unit.Angle, bool) {
 				digitsParsed++
 			}
 			if digitsParsed == 3 {
-				return bearing, true
+				return bearings.NewMagneticBearing(bearing), true
 			}
 		}
 		ok := scanner.Scan()
 		if !ok {
-			return bearing, true
+			return bearings.NewMagneticBearing(bearing), true
 		}
 	}
-	return 0 * unit.Degree, false
+	return bearings.NewMagneticBearing(0), false
 }
 
 // parseRange parses a distance. The number must be pronounced as a whole cardinal number.

--- a/pkg/parser/spiked_test.go
+++ b/pkg/parser/spiked_test.go
@@ -3,8 +3,10 @@ package parser
 import (
 	"testing"
 
+	"github.com/dharmab/skyeye/pkg/bearings"
 	"github.com/dharmab/skyeye/pkg/brevity"
 	"github.com/martinlindhe/unit"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParserSpiked(t *testing.T) {
@@ -13,7 +15,7 @@ func TestParserSpiked(t *testing.T) {
 			text: "ANYFACE, EAGLE 1 SPIKED 2-7-0",
 			expectedRequest: &brevity.SpikedRequest{
 				Callsign: "eagle 1",
-				Bearing:  unit.Angle(270) * unit.Degree,
+				Bearing:  bearings.NewMagneticBearing(unit.Angle(270) * unit.Degree),
 			},
 			expectedOk: true,
 		},
@@ -21,10 +23,15 @@ func TestParserSpiked(t *testing.T) {
 			text: "Anyface Raven 1-4, Spike 0-2-0",
 			expectedRequest: &brevity.SpikedRequest{
 				Callsign: "raven 1 4",
-				Bearing:  unit.Angle(20) * unit.Degree,
+				Bearing:  bearings.NewMagneticBearing(unit.Angle(20) * unit.Degree),
 			},
 			expectedOk: true,
 		},
 	}
-	runParserTestCases(t, New(TestCallsign), testCases)
+	runParserTestCases(t, New(TestCallsign), testCases, func(t *testing.T, test parserTestCase, request any) {
+		expected := test.expectedRequest.(*brevity.SpikedRequest)
+		actual := request.(*brevity.SpikedRequest)
+		require.Equal(t, expected.Callsign, actual.Callsign)
+		require.Equal(t, expected.Bearing, actual.Bearing)
+	})
 }

--- a/pkg/radar/grouping.go
+++ b/pkg/radar/grouping.go
@@ -53,7 +53,7 @@ func (s *scope) addNearbyAircraftToGroup(this *trackfiles.Trackfile, group *grou
 
 		isWithinSpread := geo.Distance(other.LastKnown().Point, this.LastKnown().Point) < spreadInterval.Meters()
 		isWithinStack := math.Abs(other.LastKnown().Altitude.Feet()-this.LastKnown().Altitude.Feet()) < stackInterval.Feet()
-		log.Debug().
+		log.Trace().
 			Any("initialContact", this.Contact).
 			Any("contact", other.Contact).
 			Int("unitID", int(other.Contact.UnitID)).

--- a/pkg/radar/radar.go
+++ b/pkg/radar/radar.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/dharmab/skyeye/internal/conf"
+	"github.com/dharmab/skyeye/pkg/bearings"
 	"github.com/dharmab/skyeye/pkg/brevity"
 	"github.com/dharmab/skyeye/pkg/coalitions"
 	"github.com/dharmab/skyeye/pkg/encyclopedia"
@@ -15,14 +17,22 @@ import (
 )
 
 type Radar interface {
+	// SetBullseye updates the bullseye point.
+	SetBullseye(orb.Point)
+	// Bullseye returns the current bullseye point.
+	GetBullseye() orb.Point
+	// SetMissionTime updates the mission time used for computing magnetic declination.
+	SetMissionTime(time.Time)
+	/// MissionTime returns the current mission time.
+	GetMissionTime() time.Time
+	// Declination returns the magnetic declination at the given point.
+	Declination(orb.Point) unit.Angle
 	// Run consumes updates from the simulation channels until the context is cancelled.
 	Run(context.Context)
 	// FindCallsign returns the trackfile for the given callsign, or nil if no trackfile was found.
 	FindCallsign(string) *trackfiles.Trackfile
 	// FindUnit returns the trackfile for the given unit ID, or nil if no trackfile was found.
 	FindUnit(uint32) *trackfiles.Trackfile
-	// GetBullseye returns the bullseye for the configured coalition.
-	GetBullseye() orb.Point
 	// GetPicture returns a picture of the radar scope around the given location, within the given radius, filtered by the given coalition and contact category.
 	// The first return value is the total number of groups, and the second is a slice of up to to 3 high priority groups.
 	GetPicture(orb.Point, unit.Length, coalitions.Coalition, brevity.ContactCategory) (int, []brevity.Group)
@@ -42,26 +52,42 @@ type Radar interface {
 	// Returns the nearest group to the given location which matches the given coalition and filter, with Bullseye location. Returns nil if no group was found.
 	FindNearestGroupWithBullseye(orb.Point, coalitions.Coalition, brevity.ContactCategory) brevity.Group
 	// FindNearestGroupInCone returns the nearest group to the given location along the given bearing, ± the given angle, with BRAA relative to the given location. Returns nil if no group was found.
-	FindNearestGroupInCone(orb.Point, unit.Angle, unit.Angle, coalitions.Coalition, brevity.ContactCategory) brevity.Group
+	FindNearestGroupInCone(orb.Point, bearings.Bearing, unit.Angle, coalitions.Coalition, brevity.ContactCategory) brevity.Group
 }
 
 var _ Radar = &scope{}
 
 type scope struct {
-	updates   <-chan sim.Updated
-	fades     <-chan sim.Faded
-	bullseyes <-chan orb.Point
-	bullseye  orb.Point
-	contacts  contactDatabase
+	updates     <-chan sim.Updated
+	fades       <-chan sim.Faded
+	missionTime time.Time
+	bullseye    orb.Point
+	contacts    contactDatabase
 }
 
-func New(coalition coalitions.Coalition, bullseyes <-chan orb.Point, updates <-chan sim.Updated, fades <-chan sim.Faded) Radar {
+func New(coalition coalitions.Coalition, updates <-chan sim.Updated, fades <-chan sim.Faded) Radar {
 	return &scope{
-		updates:   updates,
-		fades:     fades,
-		bullseyes: bullseyes,
-		contacts:  newContactDatabase(),
+		updates:     updates,
+		fades:       fades,
+		missionTime: conf.InitialTime,
+		contacts:    newContactDatabase(),
 	}
+}
+
+func (s *scope) SetMissionTime(t time.Time) {
+	s.missionTime = t
+}
+
+func (s *scope) GetMissionTime() time.Time {
+	return s.missionTime
+}
+
+func (s *scope) SetBullseye(bullseye orb.Point) {
+	s.bullseye = bullseye
+}
+
+func (s *scope) Bullseye() orb.Point {
+	return s.bullseye
 }
 
 // Run implements [Radar.Run]
@@ -74,8 +100,6 @@ func (s *scope) Run(ctx context.Context) {
 			s.handleUpdate(update)
 		case fade := <-s.fades:
 			s.handleFade(fade)
-		case bullseye := <-s.bullseyes:
-			s.bullseye = bullseye
 		case <-ticker.C:
 			s.handleGarbageCollection()
 		case <-ctx.Done():
@@ -196,4 +220,12 @@ func (s *scope) isMatch(tf *trackfiles.Trackfile, coalition coalitions.Coalition
 	// If the aircraft is not in the encyclopedia, assume it matches
 	matchesFilter := !ok || data.Category() == filter || filter == brevity.Aircraft
 	return matchesFilter
+}
+
+func (s *scope) Declination(p orb.Point) unit.Angle {
+	declination, err := bearings.Declination(p, s.missionTime)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to get declination")
+	}
+	return declination
 }

--- a/pkg/sim/sim.go
+++ b/pkg/sim/sim.go
@@ -32,8 +32,10 @@ type Updated struct {
 
 // Faded is a message sent when an aircraft disappears.
 type Faded struct {
-	// Timestamp when the aircraft disappeared.
+	// Real-time timestamp when the aircraft disappeared.
 	Timestamp time.Time
+	// Mission time when the aircraft disappeared.
+	MissionTimestamp time.Time
 	// UnitID of the aircraft that disappeared.
 	UnitID uint32
 }

--- a/pkg/tacview/acmi/acmi.go
+++ b/pkg/tacview/acmi/acmi.go
@@ -277,7 +277,7 @@ func (s *streamer) Bullseye() orb.Point {
 }
 
 func (s *streamer) Time() time.Time {
-	return s.referenceTime
+	return s.cursorTime
 }
 
 func (s *streamer) updateBullseye(object *types.Object) error {
@@ -335,10 +335,11 @@ func (s *streamer) buildUpdate(object *types.Object) (*sim.Updated, error) {
 	}
 
 	frame := trackfiles.Frame{
-		Timestamp: time.Now(),
-		Point:     coordinates.Location,
-		Altitude:  coordinates.Altitude,
-		Heading:   coordinates.Heading,
+		Timestamp:   time.Now(),
+		MissionTime: s.cursorTime,
+		Point:       coordinates.Location,
+		Altitude:    coordinates.Altitude,
+		Heading:     coordinates.Heading,
 	}
 
 	return &sim.Updated{

--- a/pkg/tacview/client/file.go
+++ b/pkg/tacview/client/file.go
@@ -22,7 +22,7 @@ type fileClient struct {
 	*tacviewClient
 }
 
-func NewFileClient(path string, coalition coalitions.Coalition, updates chan<- sim.Updated, fades chan<- sim.Faded, bullseyes chan<- orb.Point, updateInterval time.Duration) (Client, error) {
+func NewFileClient(path string, coalition coalitions.Coalition, updates chan<- sim.Updated, fades chan<- sim.Faded, updateInterval time.Duration) (Client, error) {
 	f, err := openFile(path)
 	if err != nil {
 		return nil, err
@@ -33,8 +33,8 @@ func NewFileClient(path string, coalition coalitions.Coalition, updates chan<- s
 			coalition:      coalition,
 			updates:        updates,
 			fades:          fades,
-			bullseyes:      bullseyes,
 			updateInterval: updateInterval,
+			missionTime:    time.Unix(0, 0),
 		},
 	}, nil
 }
@@ -76,6 +76,14 @@ func (c *fileClient) Run(ctx context.Context) error {
 	reader := bufio.NewReader(c.file)
 	acmi := acmi.New(c.coalition, reader, c.updateInterval)
 	return c.tacviewClient.run(ctx, acmi)
+}
+
+func (c *fileClient) Bullseye() orb.Point {
+	return c.tacviewClient.bullseye
+}
+
+func (c *fileClient) Time() time.Time {
+	return c.tacviewClient.missionTime
 }
 
 func (c *fileClient) Close() error {

--- a/pkg/tacview/client/telemetry.go
+++ b/pkg/tacview/client/telemetry.go
@@ -31,7 +31,6 @@ func NewTelemetryClient(
 	coalition coalitions.Coalition,
 	updates chan<- sim.Updated,
 	fades chan<- sim.Faded,
-	bullseyes chan<- orb.Point,
 	updateInterval time.Duration,
 ) (Client, error) {
 	log.Info().Str("protocol", "tcp").Str("address", address).Msg("connecting to telemetry service")
@@ -51,7 +50,6 @@ func NewTelemetryClient(
 			coalition:      coalition,
 			updates:        updates,
 			fades:          fades,
-			bullseyes:      bullseyes,
 			updateInterval: updateInterval,
 		},
 	}, nil
@@ -66,6 +64,14 @@ func (c *telemetryClient) Run(ctx context.Context) error {
 
 	source := acmi.New(c.coalition, reader, c.updateInterval)
 	return c.run(ctx, source)
+}
+
+func (c *telemetryClient) Bullseye() orb.Point {
+	return c.bullseye
+}
+
+func (c *telemetryClient) Time() time.Time {
+	return c.missionTime
 }
 
 func (c *telemetryClient) handshake(reader *bufio.Reader, hostname, password string) error {

--- a/pkg/trackfiles/trackfile_test.go
+++ b/pkg/trackfiles/trackfile_test.go
@@ -177,7 +177,7 @@ func TestTracking(t *testing.T) {
 			require.InDelta(t, test.expectedApproxSpeed.MetersPerSecond(), trackfile.Speed().MetersPerSecond(), 0.5)
 			require.Equal(t, test.expectedDirection, trackfile.Direction())
 			if test.expectedDirection != brevity.UnknownDirection {
-				require.InDelta(t, bearings.Normalize(test.expectedApproxCourse).Degrees(), trackfile.Course().Degrees(), 0.5)
+				require.InDelta(t, bearings.NewMagneticBearing(test.expectedApproxCourse).Degrees(), trackfile.Course().Degrees(), 0.5)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #64 

## Magnetic Declination

Adds functionality to the bearings module to compute magnetic declination based on contextual date and time, using the [IGRF model](https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html) for years 1900-2025. This is needed because with the addition of the Kola terrain DCS now has maps where magnetic declination varies with both date and location within the map. (Neat!)

This should correct the error of a few degrees in bearings... assuming we're careful to use magnetic bearings in brevity/comms, and true headings in telemetry and geometric calculations.

To help keep track of which we're using...

## Bearings

... the bearings module has new Bearing types in the bearings package. A Bearing is a container around an Angle, normalized to the range (0°, 360°]. (i.e. if you write 0°, you will read 360°). There are two structs that implement the Bearing interface, Magnetic and True. The implementations are identical, except for two pairs of functions:

`isTrue()` and `isMagnetic()` are a quick way to check which concrete type you're working with without having to use reflection.

`True(d)` and `Magnetic(d)` will convert between the concrete type, given a magnetic declination _d_. However, you don't need to know what type you already have to perform the conversion. If you call `Magnetic(d)` on a magnetic bearing, it simply returns itself, and `True(d)` works in a similar way. This allows us to force which type of bearing we're working with based on the context.

Internal types have been changed from Angle to Bearing wherever appropriate.

## Mission Time

We need a coarsely accurate mission time to compute magnetic declination accurately, because [the magnetic field moves over time](https://www.youtube.com/watch?v=qD6bPNZRRbQ). I've modified the `Sim` interface, and the tacview ACMI implementation of the interface, to allow the current mission time to be queried. I've also added a goroutine to the application which updates this mission time regularly. Finally, I converted bullseye updates to use this same mechanic because the bullseye update channel was kinda goofy TBH- bullseye don't change during a mission.

There is a short period of time during startup where the bullseye and mission time are not initialized but this condition should clear by the time the GCI SUNRISE message has been broadcast on SRS.

## Unit Test Changes

The repeated normalization and conversion operations in the Bearing internals has exposed fragile parser tests that were checking strict equality on float64 values. These tests have been rewritten to allow the individual values to be checked with a coarser level of precision.