### PR TITLE
Remove Weeds

### DIFF
--- a/pkg/brevity/group.go
+++ b/pkg/brevity/group.go
@@ -24,8 +24,6 @@ type Group interface {
 	Bullseye() *Bullseye
 	// Altitude is the group's altitude above sea level. This may be nil for BOGEY DOPE, SNAPLOCK, and THREAT calls.
 	Altitude() unit.Length
-	// Weeds is true if the group is in the weeds (below 1000 ft AGL).
-	Weeds() bool
 	// Track is the group's track direction. This may be UnknownDirection for BOGEY DOPE, SNAPLOCK, and THREAT calls.
 	Track() Track
 	// Aspect is the group's aspect angle relative to another aircraft. This may be nil for BOGEY DOPE, SNAPLOCK, and some THREAT calls.

--- a/pkg/radar/group.go
+++ b/pkg/radar/group.go
@@ -85,12 +85,6 @@ func (g *group) Altitude() unit.Length {
 	return rounded
 }
 
-// Weeds implements [brevity.Group.Weeds]
-func (g *group) Weeds() bool {
-	// TODO use AGL instead of MSL
-	return g.Altitude() < 1000*unit.Foot
-}
-
 // Track implements [brevity.Group.Track]
 func (g *group) Track() brevity.Track {
 	if len(g.contacts) == 0 {


### PR DESCRIPTION
Remove references to weeds -- AIC shouldn't use "weeds" more of an AUX comm for fighters.