### PR TITLE
improvments from hoggit/lima kilo testing

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -57,7 +57,14 @@ Install [DCS-SRS](http://dcssimpleradio.com/). This can be on a different comput
 
 Launch the DCS server and SRS server. Load a mission on the DCS server.
 
-You will need to download an OpenAI Whisper model. The main source of these models is [Hugging Face](https://huggingface.co/ggerganov/whisper.cpp/tree/main). The larger models have better accuracy but higher memory consumption and take longer to recognize text. There are also faster distilled models available [here](https://huggingface.co/distil-whisper/distil-medium.en#whispercpp), [although these have some quality trade-offs with the library used in this software.](https://github.com/ggerganov/whisper.cpp/tree/master/models#distilled-models). Whichever model you choose, put the model next to `skyeye.exe`.
+You will need to download an OpenAI Whisper model. The main source of these models is [Hugging Face](https://huggingface.co/ggerganov/whisper.cpp/tree/main). The larger models have better accuracy but higher memory consumption and take longer to recognize text. 
+
+Recommended models:
+
+- `ggml-small.en.bin` - Good balance between accuracy and performance on high end hardware, even if you don't speak perfectly clearly.
+- `ggml-tiny.en.bin` - Significantly faster, but requires you to speak more clearly.
+
+Whichever model you choose, put the model next to `skyeye.exe`.
 
 Run SkyEye by passing command line flags to `skyeye.exe`. You can run `./skyeye.exe --help` for an example and a list of available flags. If all goes well, you should see the SkyEye software start up and start logging to the console.
 

--- a/docs/PLAYER.md
+++ b/docs/PLAYER.md
@@ -28,22 +28,25 @@ This is a silly piece of software for a silly computer game. Don't take it too s
 
 ## Choosing Your Callsign
 
-You need a callsign to use SkyEye. A callsign contains a word followed by a sequence of numbers. SkyEye will make its best effort to figure out your callsign from your in-game name, but it works best if you have a name like `Mobius 1 Reaper` (MOBIUS ONE) or `Hitman 11 Monarch` (HITMAN ONE ONE).
+You need a callsign to use SkyEye. SkyEye will make its best effort to figure out your callsign from your in-game name, but it works best if you have a name like `Mobius 1 | Reaper` (MOBIUS ONE) or `Hitman 11 | Monarch` (HITMAN ONE ONE).
 
 That is:
 
-1. A two or three syllable English word that does not have any homonyms. Avoid compound words for best results.
-2. One or two digits, none of which are 0.
-3. A name that does not contain digits.
+1. A two or three syllable English word.
+2. One to three digits.
+3. A pipe character (`|`)
+3. Your non-callsign username.
 
-Your callsign should be unique within a server. If multiple players have the same callsign, SkyEye will respond but you may receive inconsistent information. Note that callsigns are normalized in capitalization and numbers - "WARDOG 14", "Wardog 14" and "Wardog 1 4" are all considered to be the same callsign.
+Your callsign should be unique within a server. If multiple players have the same callsign, SkyEye will respond but you may receive inconsistent information. Note that callsigns are normalized in capitalization and numbers - "WARDOG 14", "Wardog 14" and "Wardog 1 4" are all considered to be the same callsign. Numbers ar pronounced individually - "Spare 15" is prnounced "Spare One Five", not "Spare Fifteen".
 
 Avoid:
 
 * Names that contain brevity codewords, including "alpha", "radio", "bogey", "picture", "declare", "snaplock", "spiked", "bullseye".
-* Names that are hard to distinguish, like "Spare"/"Spear", "Jester"/"Gesture", "Witch"/"Which". The bot will make a best effort, but may be less accurage.
-* Names that aren't widely recognized words in common parlance, like "Razgriz". The bot will make a best effort, but may be less accurate.
+* Names that are hard to distinguish, like "Spare"/"Spear", "Jester"/"Gesture", "Witch"/"Which". The bot will make a best effort, but may be less accurate.
+* Names that aren't widely recognized words in common parlance, like "Razgriz" or "Beskar". The bot will make a best effort, but may be less accurate.
 * Names in poor taste.
+
+If your callsign doesn't follow this format, SkyEye makes a best effort to understand it while still applying its parser rules. A bare username like "Jeff" (with no numbers) may still work, but do not expect this to work reliably.
 
 ## Using Skyeye
 

--- a/internal/application/app.go
+++ b/internal/application/app.go
@@ -260,7 +260,7 @@ func (a *app) parse(ctx context.Context, in <-chan string, out chan<- any) {
 				logger.Info().Any("request", request).Msg("parsed text")
 				out <- request
 			} else {
-				logger.Info().Msg("unable to parse text")
+				logger.Info().Msg("unable to parse text, could be silence, chatter, missing GCI callsign")
 			}
 		}
 	}

--- a/pkg/controller/declare.go
+++ b/pkg/controller/declare.go
@@ -12,31 +12,35 @@ func (c *controller) HandleDeclare(request *brevity.DeclareRequest) {
 	logger := log.With().Str("callsign", request.Callsign).Type("type", request).Logger()
 	logger.Debug().Msg("handling request")
 
+	logger.Info().
+		Float64("bearingDegrees", request.Location.Bearing().Degrees()).
+		Float64("distanceNM", request.Location.Distance().NauticalMiles()).
+		Float64("altitudeFeet", request.Altitude.Feet()).
+		Msg("handling DECLARE request")
+
 	if !request.Location.Bearing().IsMagnetic() {
 		logger.Error().Any("bearing", request.Location.Bearing()).Msg("bearing provided to HandleDeclare should be magnetic")
 	}
 
 	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign)
-
 	if trackfile == nil {
 		logger.Info().Msg("no trackfile found for requestor")
 		c.out <- brevity.NegativeRadarContactResponse{Callsign: request.Callsign}
 		return
 	}
-	origin := trackfile.LastKnown().Point
 
 	aoi := geo.PointAtBearingAndDistance(
 		c.scope.GetBullseye(),
 		request.Location.Bearing().True(c.scope.Declination(c.scope.GetBullseye())).Degrees(),
 		request.Location.Distance().Meters(),
 	)
-	radius := 10 * unit.NauticalMile // TODO reduce to 3 when magvar is available
+	radius := 7 * unit.NauticalMile // TODO reduce to 3 when magvar is available
 	altitudeMargin := unit.Length(5000) * unit.Foot
 	minAltitude := request.Altitude - altitudeMargin
 	maxAltitude := request.Altitude + altitudeMargin
-	friendlyGroups := c.scope.FindNearbyGroups(origin, aoi, minAltitude, maxAltitude, radius, c.coalition, brevity.Aircraft)
-	hostileGroups := c.scope.FindNearbyGroups(origin, aoi, minAltitude, maxAltitude, radius, c.hostileCoalition(), brevity.Aircraft)
-	logger.Debug().Int("friendly", len(friendlyGroups)).Int("hostile", len(hostileGroups)).Msg("queried groups near delcared location")
+	friendlyGroups := c.scope.FindNearbyGroupsWithBullseye(aoi, minAltitude, maxAltitude, radius, c.coalition, brevity.Aircraft)
+	hostileGroups := c.scope.FindNearbyGroupsWithBullseye(aoi, minAltitude, maxAltitude, radius, c.hostileCoalition(), brevity.Aircraft)
+	logger.Debug().Int("friendly", len(friendlyGroups)).Int("hostile", len(hostileGroups)).Msg("queried groups near declared location")
 
 	response := brevity.DeclareResponse{Callsign: foundCallsign}
 	if len(friendlyGroups)+len(hostileGroups) == 0 {
@@ -48,6 +52,7 @@ func (c *controller) HandleDeclare(request *brevity.DeclareRequest) {
 		response.Group = friendlyGroups[0]
 	} else if len(friendlyGroups) == 0 && len(hostileGroups) > 0 {
 		logger.Debug().Msg("hostile groups found")
+		response.Declaration = brevity.Hostile
 		response.Group = hostileGroups[0]
 	} else if len(friendlyGroups) > 0 && len(hostileGroups) > 0 {
 		logger.Debug().Msg("both friendly and hostile groups found")

--- a/pkg/controller/snaplock.go
+++ b/pkg/controller/snaplock.go
@@ -39,7 +39,7 @@ func (c *controller) HandleSnaplock(request *brevity.SnaplockRequest) {
 	altitudeMargin := unit.Length(5000) * unit.Foot
 	minAltitude := request.BRA.Altitude() - altitudeMargin
 	maxAltitude := request.BRA.Altitude() + altitudeMargin
-	friendlyGroups := c.scope.FindNearbyGroups(
+	friendlyGroups := c.scope.FindNearbyGroupsWithBRAA(
 		origin,
 		pointOfInterest,
 		minAltitude,
@@ -48,7 +48,7 @@ func (c *controller) HandleSnaplock(request *brevity.SnaplockRequest) {
 		c.coalition,
 		brevity.Aircraft,
 	)
-	hostileGroups := c.scope.FindNearbyGroups(
+	hostileGroups := c.scope.FindNearbyGroupsWithBRAA(
 		origin,
 		pointOfInterest,
 		minAltitude,

--- a/pkg/controller/unable.go
+++ b/pkg/controller/unable.go
@@ -7,9 +7,8 @@ import (
 
 func (c *controller) HandleUnableToUnderstand(request *brevity.UnableToUnderstandRequest) {
 	log.Debug().Str("callsign", request.Callsign).Type("type", request).Msg("handling request")
-	response := brevity.SayAgainResponse{Callsign: request.Callsign}
-	callsign, trackfile := c.scope.FindCallsign(request.Callsign)
-	if trackfile != nil {
+	response := brevity.SayAgainResponse{Callsign: "last caller"}
+	if callsign, trackfile := c.scope.FindCallsign(request.Callsign); trackfile != nil {
 		response.Callsign = callsign
 	}
 	c.out <- response

--- a/pkg/parser/declare_test.go
+++ b/pkg/parser/declare_test.go
@@ -59,6 +59,18 @@ func TestParserDeclare(t *testing.T) {
 				Track:    brevity.UnknownDirection,
 			},
 		},
+		{
+			text: "Anyface Goblin11, declare 052-77-2000",
+			expected: &brevity.DeclareRequest{
+				Callsign: "goblin 1 1",
+				Location: *brevity.NewBullseye(
+					bearings.NewMagneticBearing(52*unit.Degree),
+					77*unit.NauticalMile,
+				),
+				Altitude: 2000 * unit.Foot,
+				Track:    brevity.UnknownDirection,
+			},
+		},
 	}
 	runParserTestCases(t, New(TestCallsign), testCases, func(t *testing.T, test parserTestCase, request any) {
 		expected := test.expected.(*brevity.DeclareRequest)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -79,12 +79,6 @@ func TestParserAlphaCheck(t *testing.T) {
 func TestParserRadioCheck(t *testing.T) {
 	testCases := []parserTestCase{
 		{
-			text: "Any Face Intruder 1-1 ready a check",
-			expected: &brevity.RadioCheckRequest{
-				Callsign: "intruder 1 1",
-			},
-		},
-		{
 			text: "anyface Wildcat11 radio check out.",
 			expected: &brevity.RadioCheckRequest{
 				Callsign: "wildcat 1 1",
@@ -109,7 +103,7 @@ func TestParserRadioCheck(t *testing.T) {
 			},
 		},
 		{
-			text: "anyface intruder fife one radio check",
+			text: "anyface intruder five one radio check",
 			expected: &brevity.RadioCheckRequest{
 				Callsign: "intruder 5 1",
 			},
@@ -132,12 +126,6 @@ func TestParserRadioCheck(t *testing.T) {
 				Callsign: "intruder 1 1",
 			},
 		},
-		{
-			text: "anyface work out 2 1 radio check",
-			expected: &brevity.RadioCheckRequest{
-				Callsign: "workout 2 1",
-			},
-		},
 	}
 	runParserTestCases(t, New(TestCallsign), testCases, func(t *testing.T, test parserTestCase, request any) {
 		expected := test.expected.(*brevity.RadioCheckRequest)
@@ -153,6 +141,8 @@ func TestIsSimilar(t *testing.T) {
 		expected bool
 	}{
 		{"SkyEye", "Sky Eye", true},
+		{"Bandar", "Bandog", true},
+		{"Sky Eye", "Ghost Eye", false},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s_%s", test.a, test.b), func(t *testing.T) {

--- a/pkg/radar/nearby.go
+++ b/pkg/radar/nearby.go
@@ -11,9 +11,9 @@ import (
 	"github.com/paulmach/orb/geo"
 )
 
-func (s *scope) FindNearbyGroups(origin, interest orb.Point, minAltitude, maxAltitude, radius unit.Length, coalition coalitions.Coalition, filter brevity.ContactCategory) []brevity.Group {
+func (s *scope) findNearbyGroups(interest orb.Point, minAltitude, maxAltitude, radius unit.Length, coalition coalitions.Coalition, filter brevity.ContactCategory) []*group {
 	circle := geo.NewBoundAroundPoint(interest, float64(radius.Meters()))
-	groups := make([]brevity.Group, 0)
+	groups := make([]*group, 0)
 	itr := s.contacts.itr()
 	for itr.next() {
 		trackfile := itr.value()
@@ -22,21 +22,39 @@ func (s *scope) FindNearbyGroups(origin, interest orb.Point, minAltitude, maxAlt
 		inStack := minAltitude <= trackfile.LastKnown().Altitude && trackfile.LastKnown().Altitude <= maxAltitude
 		if isMatch && inCircle && inStack {
 			grp := s.findGroupForAircraft(trackfile)
-
-			bearing := bearings.NewTrueBearing(
-				unit.Angle(
-					geo.Bearing(origin, grp.point()),
-				) * unit.Degree,
-			).Magnetic(s.Declination(origin))
-			_range := unit.Length(math.Abs(geo.Distance(origin, grp.point())))
-			altitude := grp.Altitude()
-			aspect := brevity.AspectFromAngle(bearing, grp.course())
-			grp.braa = brevity.NewBRAA(bearing, _range, altitude, aspect)
-			grp.bullseye = nil
-
 			groups = append(groups, grp)
 		}
 	}
 
 	return groups
+}
+
+func (s *scope) FindNearbyGroupsWithBullseye(interest orb.Point, minAltitude, maxAltitude, radius unit.Length, coalition coalitions.Coalition, filter brevity.ContactCategory) []brevity.Group {
+	groups := s.findNearbyGroups(interest, minAltitude, maxAltitude, radius, coalition, filter)
+	result := make([]brevity.Group, 0, len(groups))
+	for _, grp := range groups {
+		result = append(result, grp)
+	}
+	return result
+}
+
+func (s *scope) FindNearbyGroupsWithBRAA(origin, interest orb.Point, minAltitude, maxAltitude, radius unit.Length, coalition coalitions.Coalition, filter brevity.ContactCategory) []brevity.Group {
+	groups := s.findNearbyGroups(interest, minAltitude, maxAltitude, radius, coalition, filter)
+	result := make([]brevity.Group, 0, len(groups))
+	for _, grp := range groups {
+		bearing := bearings.NewTrueBearing(
+			unit.Angle(
+				geo.Bearing(origin, grp.point()),
+			) * unit.Degree,
+		).Magnetic(s.Declination(origin))
+		_range := unit.Length(math.Abs(geo.Distance(origin, grp.point())))
+		altitude := grp.Altitude()
+		aspect := brevity.AspectFromAngle(bearing, grp.course())
+		grp.braa = brevity.NewBRAA(bearing, _range, altitude, aspect)
+		grp.bullseye = nil
+
+		result = append(result, grp)
+	}
+
+	return result
 }

--- a/pkg/radar/radar.go
+++ b/pkg/radar/radar.go
@@ -47,11 +47,22 @@ type Radar interface {
 		coalition coalitions.Coalition,
 		category brevity.ContactCategory,
 	) (int, []brevity.Group)
-	// FindNearbyGroups returns all groups within the given radius of the given point of interest, within the given
+	// FindNearbyGroupsWithBRAA returns all groups within the given radius of the given point of interest, within the given
 	// altitude block, filtered by the given coalition and contact category. Each group has BRAA set relative to the
 	// given origin.
-	FindNearbyGroups(
+	FindNearbyGroupsWithBRAA(
 		origin,
+		pointOfInterest orb.Point,
+		minAltitude,
+		maxAltitude,
+		radius unit.Length,
+		coalition coalitions.Coalition,
+		category brevity.ContactCategory,
+	) []brevity.Group
+	// FindNearbyGroupsWithBullseye returns all groups within the given radius of the given point of interest, within the given
+	// altitude block, filtered by the given coalition and contact category. Each group has Bullseye set relative to the
+	// point provided in SetBullseye.
+	FindNearbyGroupsWithBullseye(
 		pointOfInterest orb.Point,
 		minAltitude,
 		maxAltitude,

--- a/pkg/tacview/acmi/acmi.go
+++ b/pkg/tacview/acmi/acmi.go
@@ -345,7 +345,7 @@ func (s *streamer) buildUpdate(object *types.Object) (*sim.Updated, error) {
 		if ok {
 			logger = logger.With().Str("aircraft", acmiName).Logger()
 		}
-		logger.Warn().Str("name", name).Msg("object has no pilot, using unitID as callsign")
+		logger.Trace().Str("name", name).Msg("object has no pilot, using unitID as callsign")
 		callsign = fmt.Sprintf("Unit %d", object.ID)
 	}
 


### PR DESCRIPTION

- Fix an issue where declare responses were in BRAA format instead of BULLSEYE format
- A lot of general parser tuning and improvements. In particular the callsign parser hbas been entirely rewritten. The ggml-tiny model is now viable, though the small model is still better quality if your PC can run it
- Callsign parsing is now more permissive, e.g. "Viking" with no numbers is now a valid callsign
- Removed some parser tests that weren't applicable to real world usage due to quality improvements in the recognizer (due to prompt engineering). Added some test cases for issues that came up during the test session.
- Suppressed the annoying warning for AI aircraft with no pilot names set.