### PR TITLE
Limit recognition to first 256k elements of sample

### DIFF
--- a/pkg/recognizer/whisper.go
+++ b/pkg/recognizer/whisper.go
@@ -20,8 +20,15 @@ func NewWhisperRecognizer(model *whisper.Model) Recognizer {
 	return &whisperRecognizer{model: *model}
 }
 
+const maxSize = 256 * 1024
+
 // Recognize implements [Recognizer.Recognize] using whisper.cpp
 func (r *whisperRecognizer) Recognize(sample []float32) (string, error) {
+	if len(sample) > maxSize {
+		log.Warn().Int("byteLength", len(sample)).Int("maxSize", maxSize).Msg("clamping sample to maximum size")
+		sample = sample[:maxSize]
+	}
+
 	wCtx, err := r.model.NewContext()
 	wCtx.SetInitialPrompt("You are a Ground Control Intercept (GCI) operator. You receive text in the format ['ANYFACE' / GCI CALLSIGN] [PILOT CALLSIGN] [DIGITS] ['RADIO', 'ALPHA', 'BOGEY', 'PICTURE', 'DECLARE', 'SNAPLOCK', or 'SPIKED'] [ARGUMENTS]. Parse numbers as digits.")
 	if err != nil {


### PR DESCRIPTION
Fixes #107 

By my math 256k is 16 seconds of audio at 16KHz which should be plenty long enough for any request.