### PR TITLE
enforce requestor coalition

### DIFF
--- a/pkg/controller/alphacheck.go
+++ b/pkg/controller/alphacheck.go
@@ -9,7 +9,7 @@ import (
 func (c *controller) HandleAlphaCheck(request *brevity.AlphaCheckRequest) {
 	logger := log.With().Str("callsign", request.Callsign).Type("type", request).Logger()
 	logger.Debug().Msg("handling request")
-	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign)
+	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign, c.coalition)
 	if trackfile == nil {
 		logger.Debug().Msg("no trackfile found for requestor")
 		c.out <- brevity.AlphaCheckResponse{

--- a/pkg/controller/bogeydope.go
+++ b/pkg/controller/bogeydope.go
@@ -10,7 +10,7 @@ import (
 func (c *controller) HandleBogeyDope(request *brevity.BogeyDopeRequest) {
 	logger := log.With().Str("callsign", request.Callsign).Type("type", request).Any("filter", request.Filter).Logger()
 	logger.Debug().Msg("handling request")
-	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign)
+	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign, c.coalition)
 	if trackfile == nil {
 		logger.Info().Msg("no trackfile found for requestor")
 		c.out <- brevity.NegativeRadarContactResponse{Callsign: request.Callsign}

--- a/pkg/controller/declare.go
+++ b/pkg/controller/declare.go
@@ -22,7 +22,7 @@ func (c *controller) HandleDeclare(request *brevity.DeclareRequest) {
 		logger.Error().Any("bearing", request.Location.Bearing()).Msg("bearing provided to HandleDeclare should be magnetic")
 	}
 
-	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign)
+	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign, c.coalition)
 	if trackfile == nil {
 		logger.Info().Msg("no trackfile found for requestor")
 		c.out <- brevity.NegativeRadarContactResponse{Callsign: request.Callsign}

--- a/pkg/controller/picture.go
+++ b/pkg/controller/picture.go
@@ -10,7 +10,7 @@ func (c *controller) HandlePicture(request *brevity.PictureRequest) {
 	logger := log.With().Str("callsign", request.Callsign).Type("type", request).Logger()
 	logger.Debug().Msg("handling request")
 
-	_, trackfile := c.scope.FindCallsign(request.Callsign)
+	_, trackfile := c.scope.FindCallsign(request.Callsign, c.coalition)
 	if trackfile == nil {
 		logger.Warn().Msg("callsign not found")
 		c.out <- brevity.NegativeRadarContactResponse{Callsign: request.Callsign}

--- a/pkg/controller/radiocheck.go
+++ b/pkg/controller/radiocheck.go
@@ -9,7 +9,7 @@ import (
 func (c *controller) HandleRadioCheck(request *brevity.RadioCheckRequest) {
 	logger := log.With().Str("callsign", request.Callsign).Type("type", request).Logger()
 	logger.Debug().Msg("handling request")
-	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign)
+	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign, c.coalition)
 	status := trackfile != nil
 	if !status {
 		logger.Debug().Msg("no trackfile found for requestor")

--- a/pkg/controller/snaplock.go
+++ b/pkg/controller/snaplock.go
@@ -22,7 +22,7 @@ func (c *controller) HandleSnaplock(request *brevity.SnaplockRequest) {
 		logger.Error().Any("bearing", request.BRA.Bearing()).Msg("bearing provided to HandleSnaplock should be magnetic")
 	}
 
-	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign)
+	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign, c.coalition)
 	if trackfile == nil {
 		logger.Info().Msg("no trackfile found for requestor")
 		c.out <- brevity.NegativeRadarContactResponse{Callsign: request.Callsign}

--- a/pkg/controller/spiked.go
+++ b/pkg/controller/spiked.go
@@ -15,7 +15,7 @@ func (c *controller) HandleSpiked(request *brevity.SpikedRequest) {
 		logger.Error().Any("bearing", request.Bearing).Msg("bearing provided to HandleSpiked should be magnetic")
 	}
 
-	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign)
+	foundCallsign, trackfile := c.scope.FindCallsign(request.Callsign, c.coalition)
 
 	if trackfile == nil {
 		logger.Info().Msg("no trackfile found for requestor")

--- a/pkg/controller/unable.go
+++ b/pkg/controller/unable.go
@@ -8,7 +8,7 @@ import (
 func (c *controller) HandleUnableToUnderstand(request *brevity.UnableToUnderstandRequest) {
 	log.Debug().Str("callsign", request.Callsign).Type("type", request).Msg("handling request")
 	response := brevity.SayAgainResponse{Callsign: "last caller"}
-	if callsign, trackfile := c.scope.FindCallsign(request.Callsign); trackfile != nil {
+	if callsign, trackfile := c.scope.FindCallsign(request.Callsign, c.coalition); trackfile != nil {
 		response.Callsign = callsign
 	}
 	c.out <- response

--- a/pkg/radar/contacts.go
+++ b/pkg/radar/contacts.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dharmab/skyeye/pkg/coalitions"
 	"github.com/dharmab/skyeye/pkg/parser"
 	"github.com/dharmab/skyeye/pkg/trackfiles"
 	fuzz "github.com/hbollon/go-edlib"
@@ -13,10 +14,10 @@ import (
 
 // contactDatabase is a thread-safe trackfile database.
 type contactDatabase interface {
-	// getByCallsign returns the trackfile with the lowest edit distance to the given callsign, or nil if no closely named trackfile was found.
+	// getByCallsignAndCoalititon returns the trackfile with the lowest edit distance to the given callsign, or nil if no closely named trackfile was found.
 	// The second return value is true if a trackfile was found, and false otherwise.
 	// The callsign in the trackfile may differ from the input callsign!
-	getByCallsign(string) (string, *trackfiles.Trackfile, bool)
+	getByCallsignAndCoalititon(string, coalitions.Coalition) (string, *trackfiles.Trackfile, bool)
 	// getByUnitID returns the trackfile for the given unit ID, or nil if no trackfile was found.
 	// The second return value is true if a trackfile was found, and false otherwise.
 	getByUnitID(uint32) (*trackfiles.Trackfile, bool)
@@ -46,30 +47,34 @@ type databaseIterator interface {
 type database struct {
 	lock           sync.RWMutex
 	contacts       map[uint32]*trackfiles.Trackfile
-	callsignIdx    map[string]uint32
+	callsignIdx    map[coalitions.Coalition]map[string]uint32
 	lastUpdatedIdx map[uint32]time.Time
 }
 
 func newContactDatabase() contactDatabase {
+	callsignIdx := make(map[coalitions.Coalition]map[string]uint32)
+	for _, c := range []coalitions.Coalition{coalitions.Blue, coalitions.Red, coalitions.Neutrals} {
+		callsignIdx[c] = make(map[string]uint32)
+	}
 	return &database{
 		contacts:       make(map[uint32]*trackfiles.Trackfile),
-		callsignIdx:    make(map[string]uint32),
+		callsignIdx:    callsignIdx,
 		lastUpdatedIdx: make(map[uint32]time.Time),
 	}
 }
 
-// getByCallsign implements [contactDatabase.getByCallsign].
-func (d *database) getByCallsign(callsign string) (string, *trackfiles.Trackfile, bool) {
+// getByCallsignAndCoalititon implements [contactDatabase.getByCallsignAndCoalititon].
+func (d *database) getByCallsignAndCoalititon(callsign string, coalition coalitions.Coalition) (string, *trackfiles.Trackfile, bool) {
 	d.lock.RLock()
 	defer d.lock.RUnlock()
 
 	foundCallsign := ""
-	unitId, ok := d.callsignIdx[callsign]
+	unitId, ok := d.callsignIdx[coalition][callsign]
 	if ok {
 		foundCallsign = callsign
 	} else {
-		keys := make([]string, 0, len(d.callsignIdx))
-		for k := range d.callsignIdx {
+		keys := make([]string, 0, len(d.callsignIdx[coalition]))
+		for k := range d.callsignIdx[coalition] {
 			keys = append(keys, k)
 		}
 		log.Info().Str("callsign", callsign).Msg("callsign not found in index, attempting fuzzy search")
@@ -80,7 +85,7 @@ func (d *database) getByCallsign(callsign string) (string, *trackfiles.Trackfile
 			return "", nil, false
 		}
 		log.Info().Str("callsign", callsign).Str("foundCallsign", foundCallsign).Msg("similar callsign found in index")
-		unitId = d.callsignIdx[foundCallsign]
+		unitId = d.callsignIdx[coalition][foundCallsign]
 	}
 	contact, ok := d.contacts[unitId]
 	if !ok {
@@ -102,19 +107,19 @@ func (d *database) getByUnitID(unitId uint32) (*trackfiles.Trackfile, bool) {
 }
 
 // set implements [contactDatabase.set].
-func (d *database) set(tf *trackfiles.Trackfile) {
+func (d *database) set(trackfile *trackfiles.Trackfile) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
 	// TODO get this string munging out of here
-	callsign, _, _ := strings.Cut(tf.Contact.Name, "|")
+	callsign, _, _ := strings.Cut(trackfile.Contact.Name, "|")
 	callsign, ok := parser.ParsePilotCallsign(callsign)
 	if !ok {
-		callsign = tf.Contact.Name
+		callsign = trackfile.Contact.Name
 	}
-	d.callsignIdx[callsign] = tf.Contact.UnitID
-	d.contacts[tf.Contact.UnitID] = tf
-	d.lastUpdatedIdx[tf.Contact.UnitID] = time.Now()
+	d.callsignIdx[trackfile.Contact.Coalition][callsign] = trackfile.Contact.UnitID
+	d.contacts[trackfile.Contact.UnitID] = trackfile
+	d.lastUpdatedIdx[trackfile.Contact.UnitID] = time.Now()
 }
 
 // lastUpdated implements [contactDatabase.lastUpdated].
@@ -133,7 +138,7 @@ func (d *database) delete(unitId uint32) bool {
 
 	contact, ok := d.contacts[unitId]
 	if ok {
-		delete(d.callsignIdx, contact.Contact.Name)
+		delete(d.callsignIdx[contact.Contact.Coalition], contact.Contact.Name)
 	}
 	delete(d.contacts, unitId)
 	delete(d.lastUpdatedIdx, unitId)

--- a/pkg/radar/contacts_test.go
+++ b/pkg/radar/contacts_test.go
@@ -26,17 +26,20 @@ func TestGetByCallsign(t *testing.T) {
 	}
 	d.set(trackfile)
 
-	name, tf, ok := d.getByCallsign("mobius 1")
+	name, tf, ok := d.getByCallsignAndCoalititon("mobius 1", coalitions.Blue)
 	require.True(t, ok)
 	require.Equal(t, "mobius 1", name)
 	require.EqualValues(t, trackfile, tf)
 
-	name, tf, ok = d.getByCallsign("moebius 1")
+	_, _, ok = d.getByCallsignAndCoalititon("mobius 1", coalitions.Red)
+	require.False(t, ok)
+
+	name, tf, ok = d.getByCallsignAndCoalititon("moebius 1", coalitions.Blue)
 	require.True(t, ok)
 	require.Equal(t, "mobius 1", name)
 	require.EqualValues(t, trackfile, tf)
 
-	_, _, ok = d.getByCallsign("yellow 13")
+	_, _, ok = d.getByCallsignAndCoalititon("yellow 13", coalitions.Red)
 	require.False(t, ok)
 }
 
@@ -68,7 +71,7 @@ func TestRealCallsigns(t *testing.T) {
 	for i, test := range testCases {
 		parsedCallsign, ok := parser.ParsePilotCallsign(test.Name)
 		require.True(t, ok)
-		foundCallsign, tf, ok := d.getByCallsign(test.heardAs)
+		foundCallsign, tf, ok := d.getByCallsignAndCoalititon(test.heardAs, coalitions.Blue)
 		require.True(t, ok, "queried %s, expected %s, but result was %v", test.heardAs, test.Name, ok)
 		require.Equal(t, parsedCallsign, foundCallsign)
 		require.EqualValues(t, uint32(i), tf.Contact.UnitID)

--- a/pkg/radar/grouping.go
+++ b/pkg/radar/grouping.go
@@ -11,13 +11,13 @@ import (
 )
 
 // findGroupForAircraft creates a new group for the given trackfile and adds all nearby aircraft which can be considered part of the group.
-func (s *scope) findGroupForAircraft(tf *trackfiles.Trackfile) *group {
-	if tf == nil {
+func (s *scope) findGroupForAircraft(trackfile *trackfiles.Trackfile) *group {
+	if trackfile == nil {
 		return nil
 	}
 	grp := newGroupUsingBullseye(s.bullseye)
-	grp.contacts = append(grp.contacts, tf)
-	s.addNearbyAircraftToGroup(tf, grp)
+	grp.contacts = append(grp.contacts, trackfile)
+	s.addNearbyAircraftToGroup(trackfile, grp)
 	return grp
 }
 

--- a/pkg/radar/id.go
+++ b/pkg/radar/id.go
@@ -1,13 +1,14 @@
 package radar
 
 import (
+	"github.com/dharmab/skyeye/pkg/coalitions"
 	"github.com/dharmab/skyeye/pkg/trackfiles"
 	"github.com/rs/zerolog/log"
 )
 
-func (s *scope) FindCallsign(callsign string) (string, *trackfiles.Trackfile) {
+func (s *scope) FindCallsign(callsign string, coalition coalitions.Coalition) (string, *trackfiles.Trackfile) {
 	log.Debug().Str("callsign", callsign).Any("contacts", s.contacts).Msg("searching scope for trackfile matching callsign")
-	foundCallsign, tf, ok := s.contacts.getByCallsign(callsign)
+	foundCallsign, tf, ok := s.contacts.getByCallsignAndCoalititon(callsign, coalition)
 	if !ok {
 		return callsign, nil
 	}
@@ -15,7 +16,7 @@ func (s *scope) FindCallsign(callsign string) (string, *trackfiles.Trackfile) {
 }
 
 func (s *scope) FindUnit(unitId uint32) *trackfiles.Trackfile {
-	log.Debug().Uint32("unitId", unitId).Any("contacts", s.contacts).Msg("searching scope for trackfile matching unitId")
+	log.Debug().Uint32("unitId", unitId).Any("contacts", s.contacts).Msg("searching scope for trackfile matching unitId and coalition")
 	trackfile, ok := s.contacts.getByUnitID(unitId)
 	if !ok {
 		return nil


### PR DESCRIPTION
Prevent players from impersonating aircraft from the other coalition in requests.

Fixes #116 