### PR TITLE
wait on waitgroup

### DIFF
--- a/pkg/simpleradio/audio/ping.go
+++ b/pkg/simpleradio/audio/ping.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"sync"
 	"time"
 
 	srs "github.com/dharmab/skyeye/pkg/simpleradio/types"
@@ -14,9 +15,11 @@ import (
 const pingInterval = 15 * time.Second
 
 // sendPings is a loop which sends the client GUID to the server at regular intervals to keep our connection alive.
-func (c *audioClient) sendPings(ctx context.Context) {
+func (c *audioClient) sendPings(ctx context.Context, wg *sync.WaitGroup) {
 	log.Info().Dur("interval", pingInterval).Msg("starting pings")
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		time.Sleep(1 * time.Second)
 		c.SendPing()
 	}()

--- a/pkg/simpleradio/audio/receive.go
+++ b/pkg/simpleradio/audio/receive.go
@@ -18,7 +18,11 @@ const maxRxGap = 300 * time.Millisecond
 func (c *audioClient) receiveUDP(ctx context.Context, pingCh chan<- []byte, voiceCh chan<- []byte) {
 	for {
 		if ctx.Err() != nil {
-			log.Error().Err(ctx.Err()).Msg("stopping packet receiver due to context error")
+			if ctx.Err() == context.Canceled {
+				log.Info().Msg("stopping packet receiver due to context cancellation")
+			} else {
+				log.Error().Err(ctx.Err()).Msg("stopping packet receiver due to context error")
+			}
 			return
 		}
 

--- a/pkg/tacview/acmi/acmi.go
+++ b/pkg/tacview/acmi/acmi.go
@@ -30,7 +30,7 @@ import (
 type ACMI interface {
 	sim.Sim
 	// Start should be called before Stream() to initialize the ACMI stream.
-	Start(context.Context, context.CancelFunc) error
+	Start(context.Context) error
 }
 
 type streamer struct {
@@ -62,7 +62,7 @@ func New(coalition coalitions.Coalition, acmi *bufio.Reader, updateInterval time
 	}
 }
 
-func (s *streamer) Start(ctx context.Context, cancel context.CancelFunc) error {
+func (s *streamer) Start(ctx context.Context) error {
 	log.Info().Msg("starting ACMI protocol handler")
 	for {
 		select {
@@ -76,8 +76,7 @@ func (s *streamer) Start(ctx context.Context, cancel context.CancelFunc) error {
 					s.catchUpCounter++
 					time.Sleep(1 * time.Second)
 					if s.catchUpCounter > 120 {
-						log.Warn().Int("count", s.catchUpCounter).Msg("!!! SUSPECTED END OF STREAM - POSSIBLE SERVER RESTART - CANCELING APPLICATION CONTEXT !!!")
-						cancel()
+						log.Warn().Int("count", s.catchUpCounter).Msg("!!! SUSPECTED END OF STREAM - POSSIBLE SERVER RESTART !!!")
 					}
 				} else {
 					return fmt.Errorf("error reading ACMI stream: %w", err)

--- a/pkg/tacview/client/file.go
+++ b/pkg/tacview/client/file.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/dharmab/skyeye/pkg/coalitions"
@@ -74,10 +75,10 @@ func openFile(path string) (io.ReadCloser, error) {
 	return acmi, nil
 }
 
-func (c *fileClient) Run(ctx context.Context, cancel context.CancelFunc) error {
+func (c *fileClient) Run(ctx context.Context, wg *sync.WaitGroup) error {
 	reader := bufio.NewReader(c.file)
 	acmi := acmi.New(c.coalition, reader, c.updateInterval)
-	return c.tacviewClient.run(ctx, cancel, acmi)
+	return c.tacviewClient.run(ctx, wg, acmi)
 }
 
 func (c *fileClient) Bullseye() orb.Point {

--- a/pkg/tacview/client/telemetry.go
+++ b/pkg/tacview/client/telemetry.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/dharmab/skyeye/pkg/coalitions"
@@ -55,7 +56,7 @@ func NewTelemetryClient(
 	}, nil
 }
 
-func (c *telemetryClient) Run(ctx context.Context, cancel context.CancelFunc) error {
+func (c *telemetryClient) Run(ctx context.Context, wg *sync.WaitGroup) error {
 	reader := bufio.NewReader(c.connection)
 
 	if err := c.handshake(reader, c.hostname, c.password); err != nil {
@@ -63,7 +64,7 @@ func (c *telemetryClient) Run(ctx context.Context, cancel context.CancelFunc) er
 	}
 
 	source := acmi.New(c.coalition, reader, c.updateInterval)
-	return c.run(ctx, cancel, source)
+	return c.run(ctx, wg, source)
 }
 
 func (c *telemetryClient) Bullseye() orb.Point {


### PR DESCRIPTION
Drops the shift length feature for now because turns out it was doing broken things with UDP sockets

Add a synchronized waitgroup to the app as a first step towards a proper shutdown sequence with midnight callout