### PR TITLE
Use 'hostile' instead of 'bandit'

### DIFF
--- a/docs/PLAYER.md
+++ b/docs/PLAYER.md
@@ -201,12 +201,12 @@ Examples:
 
 ```
 MOBIUS 1: "Thunderhead Mobius One, picture"
-THUNDERHEAD: "Thunderhead, 5 groups. Group bullseye 192/41, 21000, track south, bandit, Flanker. Group bullseye 178/32, 9000, track east, bandit, Frogfoot. Group bullseye 181/44, 20000, track northwest, bandit, Frogfoot."
+THUNDERHEAD: "Thunderhead, 5 groups. Group bullseye 192/41, 21000, track south, hostile, Flanker. Group bullseye 178/32, 9000, track east, hostile, Frogfoot. Group bullseye 181/44, 20000, track northwest, hostile, Frogfoot."
 ```
 
 ```
 HITMAN 11: "Galaxy Hitman One One how's the picture looking?"
-GALAXY: "Hitman One One, 6 groups. Group bullseye 211/27, 18000, track northwest, bandit, Frogfoot. Group bullseye 226/12, 7000, track northwest, bandit, Fulcrum. Group bullseye 193/47, 36000, track northeast, bandit, Foxhound."
+GALAXY: "Hitman One One, 6 groups. Group bullseye 211/27, 18000, track northwest, hostile, Frogfoot. Group bullseye 226/12, 7000, track northwest, hostile, Fulcrum. Group bullseye 193/47, 36000, track northeast, hostile, Foxhound."
 ```
 
 Tips:

--- a/pkg/controller/picture.go
+++ b/pkg/controller/picture.go
@@ -20,7 +20,7 @@ func (c *controller) HandlePicture(request *brevity.PictureRequest) {
 	logger.Debug().Msg("building picture")
 	count, groups := c.scope.GetPicture(trackfile.LastKnown().Point, request.Radius, c.hostileCoalition(), brevity.FixedWing)
 	for _, group := range groups {
-		group.SetDeclaration(brevity.Bandit)
+		group.SetDeclaration(brevity.Hostile)
 	}
 
 	logger.Debug().Int("groups", len(groups)).Int("count", count).Msg("sending response")


### PR DESCRIPTION
In DCS we can assume we are always cleared to engage the hostile coaltion, so hostile is the correct term rather than bandit.