### PR TITLE
Accept BRAA format in DECLARE

### DIFF
--- a/docs/PLAYER.md
+++ b/docs/PLAYER.md
@@ -173,9 +173,11 @@ Keyword: `DECLARE`
 
 Function: You provide the position of a radar contact on your scope. The GCI will look for contacts in that area and tell you if they are hostile, friendly, a furball (mixed) or clean (nothing on scope).
 
+You can provide the position using either Bullseye or BRAA format .
+
 Arguments:
 
-1. Bullseye (bearing and distance) (required)
+1. Bullseye (bearing and distance) or BR (bearing and range) (required)
 2. Altitude (optional)
 3. Track direction (optional)
 

--- a/pkg/brevity/declare.go
+++ b/pkg/brevity/declare.go
@@ -1,6 +1,9 @@
 package brevity
 
-import "github.com/martinlindhe/unit"
+import (
+	"github.com/dharmab/skyeye/pkg/bearings"
+	"github.com/martinlindhe/unit"
+)
 
 // Reference ATP 3-52.4 Chapter V section 6
 type Declaration string
@@ -37,8 +40,14 @@ const (
 type DeclareRequest struct {
 	// Callsign of the friendly aircraft requesting DECLARE.
 	Callsign string
-	// Location of the contact.
-	Location Bullseye
+	// IsBRAA indicates if the contact is provided using Bullseye (false) or BRAA (true).
+	IsBRAA bool
+	// Bullseye of the contact, if provided using Bullseye.
+	Bullseye Bullseye
+	// Bearing of the contact, if provided using BRAA.
+	Bearing bearings.Bearing
+	/// Range to the contact, if provided using BRAA.
+	Range unit.Length
 	// Altitude of the contact above sea level, rounded to the nearest thousands of feet.
 	Altitude unit.Length
 	// Track direction. Optional, used to discriminate between multiple contacts at the same location.

--- a/pkg/parser/declare.go
+++ b/pkg/parser/declare.go
@@ -2,28 +2,108 @@ package parser
 
 import (
 	"bufio"
+	"unicode"
 
+	"github.com/dharmab/skyeye/pkg/bearings"
 	"github.com/dharmab/skyeye/pkg/brevity"
+	"github.com/martinlindhe/unit"
 	"github.com/rs/zerolog/log"
 )
 
 func (p *parser) parseDeclare(callsign string, scanner *bufio.Scanner) (*brevity.DeclareRequest, bool) {
-	bullseye := p.parseBullseye(scanner)
-	if bullseye == nil {
-		return nil, false
+	var bullseye *brevity.Bullseye
+	var bearing bearings.Bearing
+	var _range unit.Length
+	var IsBRAA bool
+	for {
+		if scanner.Text() == "" {
+			scanner.Scan()
+			continue
+		}
+
+		// if text only contains digits, assume bullseye format
+		isNumeric := true
+		for _, r := range scanner.Text() {
+			if !unicode.IsDigit(r) {
+				isNumeric = false
+				break
+			}
+		}
+		if isNumeric {
+			log.Debug().Str("text", scanner.Text()).Msg("found numeric token, assuming format bullseye")
+			bullseye = p.parseBullseye(scanner)
+			break
+		}
+
+		parsedAsBullseye := false
+		for _, word := range bullseyeWords {
+			if IsSimilar(scanner.Text(), word) {
+				log.Debug().Str("text", scanner.Text()).Msg("found bullseye token")
+				bullseye = p.parseBullseye(scanner)
+				parsedAsBullseye = true
+				break
+			}
+		}
+		if parsedAsBullseye {
+			log.Debug().Float64("bearing", bullseye.Bearing().Degrees()).Float64("distance", bullseye.Distance().NauticalMiles()).Msg("parsed bullseye")
+			break
+		}
+
+		for _, word := range braaWords {
+			if IsSimilar(scanner.Text(), word) {
+				log.Debug().Str("text", scanner.Text()).Msg("found braa token")
+				scanner.Scan()
+				b, ok := p.parseBearing(scanner)
+				if !ok {
+					return nil, false
+				}
+				bearing = b
+				r, ok := p.parseRange(scanner)
+				if !ok {
+					return nil, false
+				}
+				_range = r
+				IsBRAA = true
+				break
+			}
+		}
+
+		if IsBRAA {
+			log.Debug().Float64("bearing", bearing.Degrees()).Float64("range", _range.NauticalMiles()).Msg("parsed bearing and range")
+			break
+		}
+
+		if ok := scanner.Scan(); !ok {
+			log.Debug().Msg("end of input")
+			return nil, false
+		}
 	}
-	log.Debug().Float64("bearing", bullseye.Bearing().Degrees()).Float64("distance", bullseye.Distance().NauticalMiles()).Msg("parsed bullseye")
+
 	altitude, ok := p.parseAltitude(scanner)
 	if !ok {
 		return nil, false
 	}
 	log.Debug().Int("altitude", int(altitude.Feet())).Msg("parsed altitude")
+
 	track := p.parseTrack(scanner)
 	log.Debug().Str("track", string(track)).Msg("parsed track")
 
+	if IsBRAA {
+		return &brevity.DeclareRequest{
+			Callsign: callsign,
+			Bearing:  bearing,
+			Range:    _range,
+			Altitude: altitude,
+			Track:    track,
+			IsBRAA:   true,
+		}, true
+	}
+	if bullseye == nil {
+		return nil, false
+	}
 	return &brevity.DeclareRequest{
 		Callsign: callsign,
-		Location: *bullseye,
+		Bullseye: *bullseye,
 		Altitude: altitude,
 		Track:    track,
 	}, true

--- a/pkg/parser/declare_test.go
+++ b/pkg/parser/declare_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dharmab/skyeye/pkg/bearings"
 	"github.com/dharmab/skyeye/pkg/brevity"
 	"github.com/martinlindhe/unit"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +16,7 @@ func TestParserDeclare(t *testing.T) {
 			text: "anyface, tater 1-1, declare bullseye 0-5-4, 123, 3000",
 			expected: &brevity.DeclareRequest{
 				Callsign: "tater 1 1",
-				Location: *brevity.NewBullseye(
+				Bullseye: *brevity.NewBullseye(
 					bearings.NewMagneticBearing(54*unit.Degree),
 					123*unit.NauticalMile,
 				),
@@ -27,7 +28,7 @@ func TestParserDeclare(t *testing.T) {
 			text: "anyface Fox 1 2 declare bullseye 043 102 12,000",
 			expected: &brevity.DeclareRequest{
 				Callsign: "fox 1 2",
-				Location: *brevity.NewBullseye(
+				Bullseye: *brevity.NewBullseye(
 					bearings.NewMagneticBearing(43*unit.Degree),
 					102*unit.NauticalMile,
 				),
@@ -39,7 +40,7 @@ func TestParserDeclare(t *testing.T) {
 			text: "anyface, Chaos 11, declare bullseye 076 44 3000.",
 			expected: &brevity.DeclareRequest{
 				Callsign: "chaos 1 1",
-				Location: *brevity.NewBullseye(
+				Bullseye: *brevity.NewBullseye(
 					bearings.NewMagneticBearing(76*unit.Degree),
 					44*unit.NauticalMile,
 				),
@@ -51,7 +52,7 @@ func TestParserDeclare(t *testing.T) {
 			text: "anyface, dog one one, declare, bullseye 075-26-2000",
 			expected: &brevity.DeclareRequest{
 				Callsign: "dog 1 1",
-				Location: *brevity.NewBullseye(
+				Bullseye: *brevity.NewBullseye(
 					bearings.NewMagneticBearing(75*unit.Degree),
 					26*unit.NauticalMile,
 				),
@@ -63,7 +64,7 @@ func TestParserDeclare(t *testing.T) {
 			text: "Anyface Goblin11, declare 052-77-2000",
 			expected: &brevity.DeclareRequest{
 				Callsign: "goblin 1 1",
-				Location: *brevity.NewBullseye(
+				Bullseye: *brevity.NewBullseye(
 					bearings.NewMagneticBearing(52*unit.Degree),
 					77*unit.NauticalMile,
 				),
@@ -71,14 +72,68 @@ func TestParserDeclare(t *testing.T) {
 				Track:    brevity.UnknownDirection,
 			},
 		},
+		{
+			text: "anyface, Chaos 11, declare braa 176 24 3000",
+			expected: &brevity.DeclareRequest{
+				Callsign: "chaos 1 1",
+				Bearing:  bearings.NewMagneticBearing(176 * unit.Degree),
+				Range:    24 * unit.NauticalMile,
+				Altitude: 3000 * unit.Foot,
+				Track:    brevity.UnknownDirection,
+				IsBRAA:   true,
+			},
+		},
+		{
+			text: "anyface, Chaos 11, declare braa 176 24 3000",
+			expected: &brevity.DeclareRequest{
+				Callsign: "chaos 1 1",
+				Bearing:  bearings.NewMagneticBearing(176 * unit.Degree),
+				Range:    24 * unit.NauticalMile,
+				Altitude: 3000 * unit.Foot,
+				Track:    brevity.UnknownDirection,
+				IsBRAA:   true,
+			},
+		},
+		{
+			text: "anyface, Chaos 11, declare a contact at braa 176 24 3000",
+			expected: &brevity.DeclareRequest{
+				Callsign: "chaos 1 1",
+				Bearing:  bearings.NewMagneticBearing(176 * unit.Degree),
+				Range:    24 * unit.NauticalMile,
+				Altitude: 3000 * unit.Foot,
+				Track:    brevity.UnknownDirection,
+				IsBRAA:   true,
+			},
+		},
+		{
+			text: "Anyface. Scorpio 21. Declare. Bra 068, 116, 15,000.",
+			expected: &brevity.DeclareRequest{
+				Callsign: "scorpio 2 1",
+				Bearing:  bearings.NewMagneticBearing(68 * unit.Degree),
+				Range:    116 * unit.NauticalMile,
+				Altitude: 15000 * unit.Foot,
+				Track:    brevity.UnknownDirection,
+				IsBRAA:   true,
+			},
+		},
 	}
 	runParserTestCases(t, New(TestCallsign), testCases, func(t *testing.T, test parserTestCase, request any) {
 		expected := test.expected.(*brevity.DeclareRequest)
 		actual := request.(*brevity.DeclareRequest)
-		require.Equal(t, expected.Callsign, actual.Callsign)
-		require.InDelta(t, expected.Location.Bearing().Degrees(), actual.Location.Bearing().Degrees(), 0.5)
-		require.InDelta(t, expected.Location.Distance().NauticalMiles(), actual.Location.Distance().NauticalMiles(), 1)
-		require.InDelta(t, expected.Altitude.Feet(), actual.Altitude.Feet(), 50)
-		require.Equal(t, expected.Track, actual.Track)
+		assert.Equal(t, expected.Callsign, actual.Callsign)
+		if expected.IsBRAA {
+			assert.True(t, actual.IsBRAA)
+			require.NotNil(t, actual.Bearing)
+			assert.InDelta(t, expected.Bearing.Degrees(), actual.Bearing.Degrees(), 0.5)
+			require.NotNil(t, actual.Range)
+			assert.InDelta(t, expected.Range.NauticalMiles(), actual.Range.NauticalMiles(), 0.5)
+		} else {
+			assert.False(t, actual.IsBRAA)
+			require.NotNil(t, actual.Bullseye)
+			assert.InDelta(t, expected.Bullseye.Bearing().Degrees(), actual.Bullseye.Bearing().Degrees(), 0.5)
+			assert.InDelta(t, expected.Bullseye.Distance().NauticalMiles(), actual.Bullseye.Distance().NauticalMiles(), 1)
+		}
+		assert.InDelta(t, expected.Altitude.Feet(), actual.Altitude.Feet(), 50)
+		assert.Equal(t, expected.Track, actual.Track)
 	})
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -111,7 +111,6 @@ func spaceDigits(tx string) string {
 			txBuilder.WriteRune(' ')
 		}
 		txBuilder.WriteRune(char)
-
 	}
 	tx = txBuilder.String()
 	return normalize(tx)

--- a/pkg/parser/spatial.go
+++ b/pkg/parser/spatial.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"bufio"
-	"slices"
 
 	"github.com/dharmab/skyeye/pkg/bearings"
 	"github.com/dharmab/skyeye/pkg/brevity"
@@ -11,13 +10,15 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var bullseyeWords = []string{"bullseye", "bulls", "eye"}
+var bullseyeWords = []string{"bullseye", "bulls"}
 
 func (p *parser) parseBullseye(scanner *bufio.Scanner) *brevity.Bullseye {
-	for slices.Contains(bullseyeWords, scanner.Text()) {
-		ok := scanner.Scan()
-		if !ok {
-			return nil
+	for _, word := range bullseyeWords {
+		if IsSimilar(scanner.Text(), word) {
+			ok := scanner.Scan()
+			if !ok {
+				return nil
+			}
 		}
 	}
 
@@ -44,10 +45,12 @@ func (p *parser) parseBullseye(scanner *bufio.Scanner) *brevity.Bullseye {
 var braaWords = []string{"bra", "brah", "braa"}
 
 func (p *parser) parseBRA(scanner *bufio.Scanner) (brevity.BRA, bool) {
-	for slices.Contains(braaWords, scanner.Text()) {
-		ok := scanner.Scan()
-		if !ok {
-			return nil, false
+	for _, word := range braaWords {
+		if IsSimilar(scanner.Text(), word) {
+			ok := scanner.Scan()
+			if !ok {
+				return nil, false
+			}
 		}
 	}
 


### PR DESCRIPTION
Allow users to provide DECLARE locations in BRAA format by saying "BRAA"  in front of the bearing.

If neither is provided, this assumes BULLSEYE.

Closes #106 