### PR TITLE
fix systemic issues handling bullseyes

### DIFF
--- a/docs/PLAYER.md
+++ b/docs/PLAYER.md
@@ -75,7 +75,7 @@ Some types of requests require you to provide numeric arguments.
 * All other numbers should be given normally - "Seventeen", not "One Seven"
 * Do not use ICAO pronunciation; pronounce numbers normally. Say "Three", "Five", "Nine", not "Tree", "Fife", "Niner".
 * When providing bullseye coordinates, you may either say "bullseye" before the coordinates, or omit the word "bullseye". That is, both "Bullseye Zero Six Five, Ninety-Nine" and "Zero Six Five, Ninety-Nine" are acceptable.
-* When providing bullseye coordinates, speak at a steady and measured pace with a slight p;ause between each number. Not too fast, not too slow. Don't mush your numbers together.
+* When providing bullseye coordinates, speak at a steady and measured pace with a slight pause between each number. Not too fast, not too slow. Don't mush your numbers together.
 
 Tips:
 

--- a/pkg/coalitions/coalition.go
+++ b/pkg/coalitions/coalition.go
@@ -12,3 +12,8 @@ const (
 	// Neutrals is the ID of the neutral coalition.
 	Neutrals = 3
 )
+
+// All returns all coalitions.
+func All() []Coalition {
+	return []Coalition{Red, Blue, Neutrals}
+}

--- a/pkg/controller/alphacheck.go
+++ b/pkg/controller/alphacheck.go
@@ -19,7 +19,8 @@ func (c *controller) HandleAlphaCheck(request *brevity.AlphaCheckRequest) {
 		return
 	}
 	logger.Debug().Msg("found requestor's trackfile")
-	location := trackfile.Bullseye(c.scope.GetBullseye())
+	bullseye := c.scope.Bullseye(trackfile.Contact.Coalition)
+	location := trackfile.Bullseye(bullseye)
 	c.out <- brevity.AlphaCheckResponse{
 		Callsign: foundCallsign,
 		Status:   true,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -85,7 +85,7 @@ func (c *controller) SetTime(t time.Time) {
 
 // SetBullseye implements [Controller.SetBullseye].
 func (c *controller) SetBullseye(bullseye orb.Point) {
-	c.scope.SetBullseye(bullseye)
+	c.scope.SetBullseye(bullseye, c.coalition)
 }
 
 // hostileCoalition returns the coalition that is hostile to the controller's coalition.

--- a/pkg/controller/declare.go
+++ b/pkg/controller/declare.go
@@ -59,7 +59,7 @@ func (c *controller) HandleDeclare(request *brevity.DeclareRequest) {
 		if !request.Bullseye.Bearing().IsMagnetic() {
 			logger.Warn().Any("bearing", request.Bullseye.Bearing()).Msg("bearing provided to HandleDeclare should be magnetic")
 		}
-		origin = c.scope.GetBullseye()
+		origin = c.scope.Bullseye(trackfile.Contact.Coalition)
 		bearing = request.Bullseye.Bearing().True(c.scope.Declination(origin))
 		distance = request.Bullseye.Distance()
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -245,7 +245,7 @@ func ParsePilotCallsign(tx string) (callsign string, isValid bool) {
 		return "", false
 	}
 
-	log.Debug().Str("callsign", callsign).Str("text", tx).Msg("parsed callsign")
+	log.Trace().Str("callsign", callsign).Str("text", tx).Msg("parsed callsign")
 	return callsign, true
 
 }

--- a/pkg/radar/grouping.go
+++ b/pkg/radar/grouping.go
@@ -15,7 +15,8 @@ func (s *scope) findGroupForAircraft(trackfile *trackfiles.Trackfile) *group {
 	if trackfile == nil {
 		return nil
 	}
-	grp := newGroupUsingBullseye(s.bullseye)
+	bullseye := s.Bullseye(trackfile.Contact.Coalition)
+	grp := newGroupUsingBullseye(bullseye)
 	grp.contacts = append(grp.contacts, trackfile)
 	s.addNearbyAircraftToGroup(trackfile, grp)
 	return grp

--- a/pkg/sim/sim.go
+++ b/pkg/sim/sim.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/dharmab/skyeye/pkg/coalitions"
 	"github.com/dharmab/skyeye/pkg/trackfiles"
 	"github.com/paulmach/orb"
 )
@@ -17,7 +18,7 @@ type Sim interface {
 	// This function blocks until the context is cancelled.
 	Stream(context.Context, chan<- Updated, chan<- Faded)
 	// Bullseye returns the coalition's bullseye center.
-	Bullseye() orb.Point
+	Bullseye(coalitions.Coalition) orb.Point
 	// Time returns the starting time of the mission.
 	// This is useful for looking up magnetic variation.
 	Time() time.Time

--- a/pkg/simpleradio/audio/transmit.go
+++ b/pkg/simpleradio/audio/transmit.go
@@ -16,7 +16,7 @@ func (c *audioClient) transmit(ctx context.Context, packetCh <-chan []voice.Voic
 		case packets := <-packetCh:
 			c.tx(packets)
 			// Pause between transmissions to sound more natural.
-			pause := time.Duration(250+rand.Intn(400)) * time.Millisecond
+			pause := time.Duration(500+rand.Intn(500)) * time.Millisecond
 			time.Sleep(pause)
 		case <-ctx.Done():
 			log.Info().Msg("stopping voice transmitter due to context cancellation")

--- a/pkg/tacview/client/telemetry.go
+++ b/pkg/tacview/client/telemetry.go
@@ -12,7 +12,6 @@ import (
 	"github.com/dharmab/skyeye/pkg/sim"
 	"github.com/dharmab/skyeye/pkg/tacview/acmi"
 	"github.com/dharmab/skyeye/pkg/tacview/types"
-	"github.com/paulmach/orb"
 	"github.com/rs/zerolog/log"
 )
 
@@ -43,16 +42,12 @@ func NewTelemetryClient(
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to telemetry service %v: %w", address, err)
 	}
+	tacviewClient := newTacviewClient(updates, fades, updateInterval)
 	return &telemetryClient{
-		connection: connection,
-		hostname:   clientHostname,
-		password:   password,
-		tacviewClient: &tacviewClient{
-			coalition:      coalition,
-			updates:        updates,
-			fades:          fades,
-			updateInterval: updateInterval,
-		},
+		connection:    connection,
+		hostname:      clientHostname,
+		password:      password,
+		tacviewClient: tacviewClient,
 	}, nil
 }
 
@@ -63,12 +58,8 @@ func (c *telemetryClient) Run(ctx context.Context, wg *sync.WaitGroup) error {
 		return fmt.Errorf("handshake error: %w", err)
 	}
 
-	source := acmi.New(c.coalition, reader, c.updateInterval)
+	source := acmi.New(reader, c.updateInterval)
 	return c.run(ctx, wg, source)
-}
-
-func (c *telemetryClient) Bullseye() orb.Point {
-	return c.bullseye
 }
 
 func (c *telemetryClient) Time() time.Time {

--- a/pkg/tacview/types/object.go
+++ b/pkg/tacview/types/object.go
@@ -187,3 +187,7 @@ func (o *Object) GetLength(property string) (unit.Length, error) {
 	}
 	return unit.Length(n) * unit.Meter, nil
 }
+
+func (o *Object) Properties() map[string]string {
+	return o.properties
+}


### PR DESCRIPTION
Bot didn't handle bullseyes for multiple coalitions correctly and would overwrite blue's bullseye with red's randomly. Most components now store a map of all bullseyes.

Interestingly, this may open the possibility of a single instance of Skyeye serving multiple coalitions as a post-launch feature... might be cool if we decide to seriously pursue PvP support in the future.