### PR TITLE
Remove real-time timestamp from trackfiles

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -51,6 +51,7 @@ var alternateRequestWords = map[string]string{
 	"bokeydope":  bogeyDope,
 	"bokey":      bogeyDope,
 	"bokeh":      bogeyDope,
+	"bogy":       bogeyDope,
 	"bogeydope":  bogeyDope,
 	"okey":       bogeyDope,
 	"boogie":     bogeyDope,
@@ -82,7 +83,7 @@ func (p *parser) findGCICallsign(fields []string) (string, string, bool) {
 func findRequestWord(fields []string) (string, int, bool) {
 	for i, field := range fields {
 		for _, word := range requestWords {
-			if IsSimilar(string(word), field) {
+			if IsSimilar(word, field) {
 				return word, i, true
 			}
 		}
@@ -93,12 +94,13 @@ func findRequestWord(fields []string) (string, int, bool) {
 func normalize(tx string) string {
 	tx, _, _ = strings.Cut(tx, "|")
 	tx = strings.ToLower(tx)
-	tx = strings.ReplaceAll(tx, ",", "")
-	tx = strings.ReplaceAll(tx, ".", "")
+	for _, r := range ".,;:!?()[]/\\" {
+		tx = strings.ReplaceAll(tx, string(r), "")
+	}
 	tx = strings.ReplaceAll(tx, "-", " ")
 	tx = strings.TrimSpace(tx)
 	for alt, word := range alternateRequestWords {
-		tx = strings.ReplaceAll(tx, alt, string(word))
+		tx = strings.ReplaceAll(tx, alt, word)
 	}
 	tx = strings.Join(strings.Fields(tx), " ")
 	return tx
@@ -136,7 +138,7 @@ func (p *parser) Parse(tx string) any {
 	var requestArgs []string
 	requestWord, requestWordIndex, foundRequestWord := findRequestWord(fields)
 	if foundRequestWord {
-		logger = logger.With().Str("request", string(requestWord)).Logger()
+		logger = logger.With().Str("request", requestWord).Logger()
 		logger.Debug().Int("position", requestWordIndex).Msg("found request word")
 		before, requestArgs = fields[:requestWordIndex], fields[requestWordIndex+1:]
 	}

--- a/pkg/radar/contacts_test.go
+++ b/pkg/radar/contacts_test.go
@@ -118,7 +118,7 @@ func TestSet(t *testing.T) {
 	require.EqualValues(t, trackfile, val)
 
 	trackfile.Update(trackfiles.Frame{
-		Timestamp: time.Now(),
+		Time: time.Now(),
 		Point: orb.Point{
 			1,
 			1,

--- a/pkg/radar/group.go
+++ b/pkg/radar/group.go
@@ -220,8 +220,8 @@ func (g *group) point() orb.Point {
 func (g *group) missionTime() time.Time {
 	latest := conf.InitialTime
 	for _, trackfile := range g.contacts {
-		if trackfile.LastKnown().MissionTime.After(latest) {
-			latest = trackfile.LastKnown().Timestamp
+		if trackfile.LastKnown().Time.After(latest) {
+			latest = trackfile.LastKnown().Time
 		}
 	}
 	return latest

--- a/pkg/radar/radar.go
+++ b/pkg/radar/radar.go
@@ -197,15 +197,11 @@ func (s *scope) handleGarbageCollection() {
 			Str("aircraft", trackfile.Contact.ACMIName).
 			Logger()
 
-		lastSeen, ok := s.contacts.lastUpdated(trackfile.Contact.UnitID)
-		if !ok {
-			logger.Warn().Msg("last updated time is missing")
-			continue
-		}
-		if lastSeen.Before(time.Now().Add(-5 * time.Minute)) {
+		lastSeen := trackfile.LastKnown().Time
+		if lastSeen.Before(s.missionTime.Add(-5 * time.Minute)) {
 			s.contacts.delete(trackfile.Contact.UnitID)
 			logger.Info().
-				Dur("age", time.Since(lastSeen)).
+				Dur("age", s.missionTime.Sub(lastSeen)).
 				Msg("removed aged out trackfile")
 		}
 	}

--- a/pkg/tacview/acmi/acmi.go
+++ b/pkg/tacview/acmi/acmi.go
@@ -349,11 +349,10 @@ func (s *streamer) buildUpdate(object *types.Object) (*sim.Updated, error) {
 	}
 
 	frame := trackfiles.Frame{
-		Timestamp:   time.Now(),
-		MissionTime: s.cursorTime,
-		Point:       coordinates.Location,
-		Altitude:    coordinates.Altitude,
-		Heading:     coordinates.Heading,
+		Time:     s.cursorTime,
+		Point:    coordinates.Location,
+		Altitude: coordinates.Altitude,
+		Heading:  coordinates.Heading,
 	}
 
 	return &sim.Updated{

--- a/pkg/trackfiles/trackfile_test.go
+++ b/pkg/trackfiles/trackfile_test.go
@@ -160,20 +160,18 @@ func TestTracking(t *testing.T) {
 			alt := 20000 * unit.Foot
 
 			trackfile.Update(Frame{
-				Timestamp:   now.Add(-1 * time.Millisecond),
-				MissionTime: now.Add(-1 * test.ΔT),
-				Point:       orb.Point{-115.0338, 36.2350},
-				Altitude:    alt,
-				Heading:     test.heading,
+				Time:     now.Add(-1 * test.ΔT),
+				Point:    orb.Point{-115.0338, 36.2350},
+				Altitude: alt,
+				Heading:  test.heading,
 			})
 			dest := geo.PointAtBearingAndDistance(trackfile.LastKnown().Point, 0, test.ΔY.Meters())
 			dest = geo.PointAtBearingAndDistance(dest, 90, test.ΔX.Meters())
 			trackfile.Update(Frame{
-				Timestamp:   now,
-				MissionTime: now,
-				Point:       dest,
-				Altitude:    alt + test.ΔZ,
-				Heading:     test.heading,
+				Time:     now,
+				Point:    dest,
+				Altitude: alt + test.ΔZ,
+				Heading:  test.heading,
 			})
 
 			require.InDelta(t, test.expectedApproxSpeed.MetersPerSecond(), trackfile.Speed().MetersPerSecond(), 0.5)


### PR DESCRIPTION
Using wall clock timestamps in trackfiles is mostly fine when reading telemetry in real-time, since the latency between the observation and reading the event is pretty low and usually consistent. However, it's problematic when replaying an old track.

Using mission timestamps instead should make it easier to do things like fast-forward though an ACMI file, then pause it to debug a specific scenario.