### PR TITLE
Implement threat call system

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,16 +127,17 @@ I have some personal, selfish reasons for writing a new bot:
 1. I want to innovate and deliver new features that would be breaking changes to the OverlordBot community.
 1. Given my lack of .NET development skills, it is faster for me to write new software using technologies to which I am "native" rather than contribute to OverlordBot.
 
-### Why aren't you implementing TRIPWIRE?
+### Why didn't you implement TRIPWIRE?
 
 TRIPWIRE encourages players to think about themselves in a small bubble. It also clutters the channel with information in a format only useful to a specific player. It encourages players to act as lone wolves rather than as members of a team.
 
-Instead, I am implementing THREAT brevity. THREAT provides similar benefit to a player as a TRIPWIRE- it warns you when a hostile aircraft is a danger to you. The advantages:
+Instead, I have implemented THREAT monitoring. THREAT monitoring warns you when a hostile aircraft is a danger to your coalition. The advantages:
 
-- THREAT calls do not require you to individually register with the bot. The bot can see the radar, and it can see which players are currently on the frequency. Therefore, it can automatically make THREAT calls to players on frequency.
-- Locations in THREAT calls can be given in either BRAA or BULLSEYE format, depending on whether the call is relevant to a single aircraft or multiple aircraft.
-- A TRIPWIRE call is only given once, at a single threat range. THREAT calls can be given at multiple threat ranges, which may be configurable based on mission requirements. For example, ATP 3-52.4 recommends 35nmi and 5nmi by default, regardless of aspect.
-- By building trackfiles, the bot can determine the aspect of aircraft and provide calls independent of range. For example, if the bot sees a retreating hostile aircraft change course and turn nose-on to a friendly aircraft 45nmi away, the bot can make a THREAT call immediately for the aircraft under threat.
+- THREAT calls do not require you to individually register with the bot. The bot automatically monitors all friendly aircraft which tune to the SRS frequency.
+- Locations in THREAT calls are given in either BRAA or BULLSEYE format, depending on whether the call is relevant to a single aircraft or multiple aircraft TRIPWIRE calls only provide BRAA format.
+- THREAT monitoring provides continual updates on the threat as long as threat criteria are met, all the way til the merge. A TRIPWIRE call is only given once, at a single requested threat range. 
+- THREAT monitoring considers the bandit group's distance, platform (aircraft & weapons) and aspect (Hot, Flank, Beam, Drag). THREAT calls are broadcast earlier in the BVR timeline for bandits that present a higher relative threat. TRIPWIRE calls only consider threat range, and are broadcast at the same range regardless of other factors. 
+- THREAT monitoring deduplicates calls to multiple friendly aircraft about the same bandit group.
 
 ### Can I train the speech recognition on my voice/accent?
 

--- a/cmd/skyeye/main.go
+++ b/cmd/skyeye/main.go
@@ -46,6 +46,10 @@ var (
 	playbackSpeed                string
 	enableAutomaticPicture       bool
 	automaticPictureInterval     time.Duration
+	enableThreatMonitoring       bool
+	threatMonitoringInterval     time.Duration
+	threatMonitoringRequiresSRS  bool
+	mandatoryThreatRadiusNM      float64
 )
 
 func init() {
@@ -86,8 +90,12 @@ func init() {
 	skyeye.Flags().Var(playbackSpeedFlag, "voice-playback-speed", "Voice playback speed of GCI")
 
 	// Controller behavior
-	skyeye.Flags().BoolVar(&enableAutomaticPicture, "auto-picture", false, "Enable automatic PICTURE broadcasts")
+	skyeye.Flags().BoolVar(&enableAutomaticPicture, "auto-picture", true, "Enable automatic PICTURE broadcasts")
 	skyeye.Flags().DurationVar(&automaticPictureInterval, "auto-picture-interval", 2*time.Minute, "How often to broadcast PICTURE")
+	skyeye.Flags().BoolVar(&enableThreatMonitoring, "threat-monitoring", true, "Enable THREAT monitoring")
+	skyeye.Flags().DurationVar(&threatMonitoringInterval, "threat-monitoring-interval", 3*time.Minute, "How often to broadcast THREAT")
+	skyeye.Flags().Float64Var(&mandatoryThreatRadiusNM, "mandatory-threat-radius", 35, "Briefed radius for mandatory THREAT calls, in nautical miles")
+	skyeye.Flags().BoolVar(&threatMonitoringRequiresSRS, "threat-monitoring-requires-srs", true, "Require aircraft to be on SRS to receive THREAT calls. Only useful to disable when debugging.")
 }
 
 // Top-level CLI command
@@ -276,6 +284,10 @@ func Supervise(cmd *cobra.Command, args []string) {
 		WhisperModel:                 whisperModel,
 		Voice:                        voice,
 		PlaybackSpeed:                playbackSpeed,
+		EnableThreatMonitoring:       enableThreatMonitoring,
+		ThreatMonitoringInterval:     threatMonitoringInterval,
+		ThreatMonitoringRequiresSRS:  threatMonitoringRequiresSRS,
+		MandatoryThreatRadius:        unit.Length(mandatoryThreatRadiusNM) * unit.NauticalMile,
 	}
 
 	if enableAutomaticPicture {

--- a/docs/PLAYER.md
+++ b/docs/PLAYER.md
@@ -283,7 +283,11 @@ Requesting a PICTURE will reset the interval on any automatic broadcast.
 
 ### THREAT
 
-🚧 NOT YET IMPLEMENTED 🚧
+The GCI controller monitors for threats which are near or approaching friendly aircraft. Any hostile aircraft within 35NM of a friendly aircraft is always considered a threat. At further ranges, the bandit's aircraft capabilities, course and aspect are also considered. Threat calls are broadcast every few minutes for as long as the threat criteria are met.
+
+Threat locations are given in BRAA format if they are relevant to a single friendly aircraft, or Bullseye calls if they are relevant to multiple friendly aircraft.
+1
+Your own aircraft must be on the SRS frequency to receive THREAT monitoring.
 
 ### FADED
 

--- a/internal/application/app.go
+++ b/internal/application/app.go
@@ -117,9 +117,17 @@ func NewApplication(ctx context.Context, config conf.Configuration) (Application
 
 	log.Info().Msg("constructing radar scope")
 
-	rdr := radar.New(config.Coalition, updates, fades)
+	rdr := radar.New(config.Coalition, updates, fades, config.MandatoryThreatRadius)
 	log.Info().Msg("constructing GCI controller")
-	controller := controller.New(rdr, config.Coalition, config.SRSFrequency, config.PictureBroadcastInterval)
+	controller := controller.New(
+		rdr, srsClient,
+		config.Coalition,
+		config.SRSFrequency,
+		config.PictureBroadcastInterval,
+		config.EnableThreatMonitoring,
+		config.ThreatMonitoringInterval,
+		config.ThreatMonitoringRequiresSRS,
+	)
 
 	log.Info().Msg("constructing text composer")
 	composer := composer.New(config.Callsign)

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -46,6 +46,15 @@ type Configuration struct {
 	PlaybackSpeed float32
 	// PictureBroadcastInterval is the interval at which the controller will automatically broadcast a PICTURE.
 	PictureBroadcastInterval time.Duration
+	// EnableThreatMonitoring controls whether the controller will broadcast THREAT calls.
+	EnableThreatMonitoring bool
+	// ThreatMonitoringInterval is the cooldown period between THREAT calls.
+	ThreatMonitoringInterval time.Duration
+	// MandatoryThreatRadius is the brief range at which a THREAT call is mandatory.
+	MandatoryThreatRadius unit.Length
+	// ThreatMonitoringRequiresSRS controls whether threat calls are issued to aircraft that are not on the SRS frequency. This is mostly
+	// for debugging.
+	ThreatMonitoringRequiresSRS bool
 }
 
 var DefaultCallsigns = []string{"Sky Eye", "Thunderhead", "Eagle Eye", "Ghost Eye", "Sky Keeper", "Bandog", "Long Caster", "Galaxy"}

--- a/pkg/brevity/group.go
+++ b/pkg/brevity/group.go
@@ -45,4 +45,5 @@ type Group interface {
 	VeryFast() bool
 	// String returns a human-readable description of the group.
 	String() string
+	UnitIDs() []uint32
 }

--- a/pkg/brevity/threat.go
+++ b/pkg/brevity/threat.go
@@ -6,8 +6,8 @@ import "github.com/martinlindhe/unit"
 // THREAT is more complicated in the real world, so this bot offers a simplified version.
 // Reference: ATP 3-52.4 Chapter V section 18
 type ThreatCall struct {
-	// Callsign of the friendly aircraft under threat.
-	Callsign string
+	// Callsigns of the friendly aircraft under threat.
+	Callsigns []string
 	// Group that is threatening the friendly aircraft.
 	Group Group
 }

--- a/pkg/coalitions/coalition.go
+++ b/pkg/coalitions/coalition.go
@@ -17,3 +17,14 @@ const (
 func All() []Coalition {
 	return []Coalition{Red, Blue, Neutrals}
 }
+
+func (c Coalition) Opposite() Coalition {
+	switch c {
+	case Red:
+		return Blue
+	case Blue:
+		return Red
+	default:
+		return Neutrals
+	}
+}

--- a/pkg/composer/threat.go
+++ b/pkg/composer/threat.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/dharmab/skyeye/pkg/brevity"
 )
@@ -9,8 +10,10 @@ import (
 // ComposeThreatCall implements [Composer.ComposeThreatCall].
 func (c *composer) ComposeThreatCall(call brevity.ThreatCall) NaturalLanguageResponse {
 	group := c.ComposeGroup(call.Group)
+	callsignList := strings.Join(call.Callsigns, ", ")
+
 	return NaturalLanguageResponse{
-		Subtitle: fmt.Sprintf("%s, %s", call.Callsign, group.Subtitle),
-		Speech:   fmt.Sprintf("%s, %s", call.Callsign, group.Speech),
+		Subtitle: fmt.Sprintf("%s, %s", callsignList, group.Subtitle),
+		Speech:   fmt.Sprintf("%s, %s", callsignList, group.Speech),
 	}
 }

--- a/pkg/controller/bogeydope.go
+++ b/pkg/controller/bogeydope.go
@@ -28,7 +28,7 @@ func (c *controller) HandleBogeyDope(request *brevity.BogeyDopeRequest) {
 		lowestAltitude,
 		highestAltitude,
 		radius,
-		c.hostileCoalition(),
+		c.coalition.Opposite(),
 		request.Filter,
 	)
 

--- a/pkg/controller/declare.go
+++ b/pkg/controller/declare.go
@@ -70,7 +70,7 @@ func (c *controller) HandleDeclare(request *brevity.DeclareRequest) {
 	minAltitude := request.Altitude - altitudeMargin
 	maxAltitude := request.Altitude + altitudeMargin
 	friendlyGroups := c.scope.FindNearbyGroupsWithBullseye(aoi, minAltitude, maxAltitude, radius, c.coalition, brevity.Aircraft)
-	hostileGroups := c.scope.FindNearbyGroupsWithBullseye(aoi, minAltitude, maxAltitude, radius, c.hostileCoalition(), brevity.Aircraft)
+	hostileGroups := c.scope.FindNearbyGroupsWithBullseye(aoi, minAltitude, maxAltitude, radius, c.coalition.Opposite(), brevity.Aircraft)
 	logger.Debug().Int("friendly", len(friendlyGroups)).Int("hostile", len(hostileGroups)).Msg("queried groups near declared location")
 
 	response := brevity.DeclareResponse{Callsign: foundCallsign}

--- a/pkg/controller/faded.go
+++ b/pkg/controller/faded.go
@@ -1,1 +1,0 @@
-package controller

--- a/pkg/controller/picture.go
+++ b/pkg/controller/picture.go
@@ -18,8 +18,7 @@ func (c *controller) HandlePicture(request *brevity.PictureRequest) {
 }
 
 func (c *controller) broadcastPicture(logger *zerolog.Logger) {
-	logger.Debug().Msg("building picture")
-	count, groups := c.scope.GetPicture(conf.DefaultPictureRadius, c.hostileCoalition(), brevity.FixedWing)
+	count, groups := c.scope.GetPicture(conf.DefaultPictureRadius, c.coalition.Opposite(), brevity.FixedWing)
 	for _, group := range groups {
 		group.SetDeclaration(brevity.Hostile)
 	}

--- a/pkg/controller/snaplock.go
+++ b/pkg/controller/snaplock.go
@@ -54,7 +54,7 @@ func (c *controller) HandleSnaplock(request *brevity.SnaplockRequest) {
 		minAltitude,
 		maxAltitude,
 		radius,
-		c.hostileCoalition(),
+		c.coalition.Opposite(),
 		brevity.Aircraft,
 	)
 

--- a/pkg/controller/spiked.go
+++ b/pkg/controller/spiked.go
@@ -33,7 +33,7 @@ func (c *controller) HandleSpiked(request *brevity.SpikedRequest) {
 		distance,
 		request.Bearing,
 		arc,
-		c.hostileCoalition(),
+		c.coalition.Opposite(),
 		brevity.FixedWing,
 	)
 

--- a/pkg/controller/sunrise.go
+++ b/pkg/controller/sunrise.go
@@ -1,1 +1,0 @@
-package controller

--- a/pkg/controller/threat.go
+++ b/pkg/controller/threat.go
@@ -1,1 +1,108 @@
 package controller
+
+import (
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/dharmab/skyeye/pkg/brevity"
+	"github.com/dharmab/skyeye/pkg/parser"
+	"github.com/rs/zerolog/log"
+)
+
+type cooldownTracker struct {
+	cooldown time.Duration
+	// cooldowns maps unit IDs to the time at which the the threat cooldown expires. The threat cooldown suppresses
+	// threat calls for the threat with the given unit ID.
+	cooldowns map[uint32]time.Time
+	// lock used to synchronize access to the cooldowns map.
+	lock sync.RWMutex
+}
+
+func newCooldownTracker(cooldown time.Duration) *cooldownTracker {
+	return &cooldownTracker{
+		cooldown:  cooldown,
+		cooldowns: make(map[uint32]time.Time),
+	}
+}
+
+func (t *cooldownTracker) extendCooldown(unitID uint32) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.cooldowns[unitID] = time.Now().Add(t.cooldown)
+}
+
+func (t *cooldownTracker) isOnCooldown(unitID uint32) bool {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	cooldown, ok := t.cooldowns[unitID]
+	if !ok {
+		return false
+	}
+
+	return time.Now().Before(cooldown)
+}
+
+func (t *cooldownTracker) remove(unitID uint32) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	delete(t.cooldowns, unitID)
+}
+
+func (t *controller) broadcastThreats() {
+	if !t.enableThreatMonitoring {
+		return
+	}
+
+	threats := t.scope.Threats(t.coalition.Opposite())
+	for group, unitIDs := range threats {
+		logger := log.With().Str("group", group.String()).Uints32("unitIDs", unitIDs).Logger()
+		isOnFrequency := false
+		for _, unitID := range unitIDs {
+			if t.srsClient.IsOnFrequency(unitID) {
+				isOnFrequency = true
+			}
+			// if only one unit of multiple is on frequency, we still use bullsye instead
+			// of BRAA. can we do better?
+		}
+
+		if t.threatMonitoringRequiresSRS && !isOnFrequency {
+			logger.Trace().Msg("supressing threat call because units are not on frequency")
+			continue
+		}
+
+		recentlyNotified := true
+		for threatID := range group.UnitIDs() {
+			if !t.threatCooldowns.isOnCooldown(uint32(threatID)) {
+				recentlyNotified = false
+				break
+			}
+		}
+		if recentlyNotified {
+			logger.Trace().Msg("supressing threat call because a call was recently broadcast for this threat")
+			continue
+		}
+
+		for threatID := range group.UnitIDs() {
+			t.threatCooldowns.extendCooldown(uint32(threatID))
+		}
+
+		group.SetDeclaration(brevity.Hostile)
+		group.SetThreat(true)
+		call := brevity.ThreatCall{Group: group}
+
+		for _, unitID := range unitIDs {
+			if trackfile := t.scope.FindUnit(unitID); trackfile != nil {
+				if callsign, ok := parser.ParsePilotCallsign(trackfile.Contact.ACMIName); ok {
+					if !slices.Contains(call.Callsigns, callsign) {
+						call.Callsigns = append(call.Callsigns, callsign)
+					}
+				}
+			}
+		}
+
+		logger.Info().Any("call", call).Msg("broadcasting threat call for group")
+		t.out <- call
+	}
+}

--- a/pkg/encyclopedia/aircraft.go
+++ b/pkg/encyclopedia/aircraft.go
@@ -681,7 +681,7 @@ var aircraftData = []Aircraft{
 		OfficialName:        "SuperCobra",
 	},
 	{
-		ACMIShortName: "AJS 37",
+		ACMIShortName: "AJS37",
 		tags: map[AircraftTag]bool{
 			FixedWing: true,
 			Attack:    true,

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/dharmab/skyeye/pkg/brevity"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,6 +14,30 @@ const TestCallsign = "Skyeye"
 type parserTestCase struct {
 	text     string
 	expected any
+}
+
+func TestParsePilotCallsign(t *testing.T) {
+	testCases := []struct {
+		name     string
+		expected string
+	}{
+		{"jeff", "jeff"},
+		{"Jeff", "jeff"},
+		{"Wardog 1 4", "wardog 1 4"},
+		{"Wardog 14", "wardog 1 4"},
+		{"Wardog 1-4", "wardog 1 4"},
+		{"Mobius 1", "mobius 1"},
+		{"Red 243", "red 2 4 3"},
+		{"Red 054", "red 0 5 4"},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			actual, ok := ParsePilotCallsign(test.name)
+			require.True(t, ok)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
 }
 
 func runParserTestCases(

--- a/pkg/radar/center.go
+++ b/pkg/radar/center.go
@@ -46,14 +46,11 @@ func (s *scope) updateCenterPoint() {
 	} else {
 		newCenter = geo.Midpoint(blue, red)
 	}
-	precision := 50 * unit.NauticalMile
 	distance := unit.Length(geo.Distance(s.center, newCenter)) * unit.Meter
-	if distance > precision {
-		bearing := bearings.NewTrueBearing(unit.Angle(geo.Bearing(s.center, newCenter)) * unit.Degree)
-		s.center = newCenter
-		log.Info().
-			Float64("lon", s.center.Lon()).
-			Float64("lat", s.center.Lat()).
-			Msgf("center point shifted %.1f NM along bearing %.0f", distance.NauticalMiles(), bearing.RoundedDegrees())
-	}
+	bearing := bearings.NewTrueBearing(unit.Angle(geo.Bearing(s.center, newCenter)) * unit.Degree)
+	s.center = newCenter
+	log.Trace().
+		Float64("lon", s.center.Lon()).
+		Float64("lat", s.center.Lat()).
+		Msgf("center point shifted %.1f NM along bearing %.0f", distance.NauticalMiles(), bearing.RoundedDegrees())
 }

--- a/pkg/radar/group.go
+++ b/pkg/radar/group.go
@@ -254,3 +254,11 @@ func (g *group) threatRadius() unit.Length {
 	}
 	return highest
 }
+
+func (g *group) UnitIDs() []uint32 {
+	unitIDs := make([]uint32, 0, len(g.contacts))
+	for _, trackfile := range g.contacts {
+		unitIDs = append(unitIDs, trackfile.Contact.UnitID)
+	}
+	return unitIDs
+}

--- a/pkg/radar/id.go
+++ b/pkg/radar/id.go
@@ -3,11 +3,9 @@ package radar
 import (
 	"github.com/dharmab/skyeye/pkg/coalitions"
 	"github.com/dharmab/skyeye/pkg/trackfiles"
-	"github.com/rs/zerolog/log"
 )
 
 func (s *scope) FindCallsign(callsign string, coalition coalitions.Coalition) (string, *trackfiles.Trackfile) {
-	log.Debug().Str("callsign", callsign).Any("contacts", s.contacts).Msg("searching scope for trackfile matching callsign")
 	foundCallsign, tf, ok := s.contacts.getByCallsignAndCoalititon(callsign, coalition)
 	if !ok {
 		return callsign, nil
@@ -16,7 +14,6 @@ func (s *scope) FindCallsign(callsign string, coalition coalitions.Coalition) (s
 }
 
 func (s *scope) FindUnit(unitId uint32) *trackfiles.Trackfile {
-	log.Debug().Uint32("unitId", unitId).Any("contacts", s.contacts).Msg("searching scope for trackfile matching unitId and coalition")
 	trackfile, ok := s.contacts.getByUnitID(unitId)
 	if !ok {
 		return nil

--- a/pkg/radar/radar.go
+++ b/pkg/radar/radar.go
@@ -108,28 +108,31 @@ type Radar interface {
 	) brevity.Group
 	// SetFadedCallback sets the callback function to be called when a trackfile fades.
 	SetFadedCallback(FadedCallback)
+
+	Threats(coalitions.Coalition) map[brevity.Group][]uint32
 }
 
 var _ Radar = &scope{}
 
 type scope struct {
-	updates       <-chan sim.Updated
-	fades         <-chan sim.Faded
-	missionTime   time.Time
-	bullseyes     sync.Map
-	contacts      contactDatabase
-	fadedCallback FadedCallback
-	center        orb.Point
+	updates               <-chan sim.Updated
+	fades                 <-chan sim.Faded
+	missionTime           time.Time
+	bullseyes             sync.Map
+	contacts              contactDatabase
+	fadedCallback         FadedCallback
+	center                orb.Point
+	mandatoryThreatRadius unit.Length
 }
 
-func New(coalition coalitions.Coalition, updates <-chan sim.Updated, fades <-chan sim.Faded) Radar {
+func New(coalition coalitions.Coalition, updates <-chan sim.Updated, fades <-chan sim.Faded, mandatoryThreatRadius unit.Length) Radar {
 	return &scope{
-		updates:       updates,
-		fades:         fades,
-		missionTime:   conf.InitialTime,
-		contacts:      newContactDatabase(),
-		fadedCallback: func(brevity.Group, coalitions.Coalition) {},
-		bullseyes:     sync.Map{},
+		updates:               updates,
+		fades:                 fades,
+		missionTime:           conf.InitialTime,
+		contacts:              newContactDatabase(),
+		fadedCallback:         func(brevity.Group, coalitions.Coalition) {},
+		mandatoryThreatRadius: mandatoryThreatRadius,
 	}
 }
 

--- a/pkg/radar/threat.go
+++ b/pkg/radar/threat.go
@@ -1,0 +1,64 @@
+package radar
+
+import (
+	"math"
+
+	"github.com/dharmab/skyeye/pkg/bearings"
+	"github.com/dharmab/skyeye/pkg/brevity"
+	"github.com/dharmab/skyeye/pkg/coalitions"
+	"github.com/martinlindhe/unit"
+	"github.com/paulmach/orb/geo"
+)
+
+func (s *scope) Threats(coalition coalitions.Coalition) map[brevity.Group][]uint32 {
+	threats := make(map[*group][]uint32)
+	hostileGroups := s.enumerateGroups(coalition)
+	for _, grp := range hostileGroups {
+		friendlyGroups := s.findNearbyGroups(
+			grp.point(),
+			0,
+			math.MaxFloat64,
+			100*unit.NauticalMile,
+			coalition.Opposite(),
+			brevity.Aircraft,
+		)
+
+		// Populate threats map with hostile-friendly relations that meet threat criteria.
+		unitIDs := make([]uint32, 0)
+		for _, friendlyGroup := range friendlyGroups {
+			distance := unit.Length(geo.Distance(grp.point(), friendlyGroup.point())) * unit.Meter
+			withinThreatRadius := distance < grp.threatRadius() || distance < s.mandatoryThreatRadius
+			groupIsRotaryAgainstPlane := grp.category() == brevity.RotaryWing && friendlyGroup.category() == brevity.FixedWing
+			if withinThreatRadius && !groupIsRotaryAgainstPlane {
+				unitIDs = append(unitIDs, friendlyGroup.UnitIDs()...)
+			}
+		}
+		if len(unitIDs) == 0 {
+			continue
+		}
+		threats[grp] = unitIDs
+
+		// If the hostile group only threatens a single friendly unit, use BRAA instead of Bullseye.
+		if len(threats[grp]) == 1 {
+			trackfile, ok := s.contacts.getByUnitID(threats[grp][0])
+			if !ok {
+				continue
+			}
+			bearing := bearings.NewTrueBearing(
+				unit.Angle(
+					geo.Bearing(trackfile.LastKnown().Point, grp.point()),
+				) * unit.Degree,
+			).Magnetic(s.Declination(trackfile.LastKnown().Point))
+			_range := unit.Length(geo.Distance(trackfile.LastKnown().Point, grp.point()))
+			aspect := brevity.AspectFromAngle(bearing, grp.course())
+			grp.braa = brevity.NewBRAA(bearing, _range, grp.Altitude(), aspect)
+			grp.bullseye = nil
+		}
+	}
+
+	result := make(map[brevity.Group][]uint32)
+	for grp, unitIDs := range threats {
+		result[grp] = unitIDs
+	}
+	return result
+}

--- a/pkg/simpleradio/client.go
+++ b/pkg/simpleradio/client.go
@@ -26,6 +26,8 @@ type Client interface {
 	Receive() <-chan audio.Audio
 	// Transmit queues a transmission to send over the radio. The audio data should be in F32LE PCM format.
 	Transmit(audio.Audio)
+	// IsOnFrequency checks if the given unit ID is on the client's frequency.
+	IsOnFrequency(unitID uint32) bool
 }
 
 // client implements the SRS Client.
@@ -114,4 +116,9 @@ func (c *client) Receive() <-chan audio.Audio {
 // Transmit implements Client.Transmit.
 func (c *client) Transmit(sample audio.Audio) {
 	c.audioClient.Transmit(sample)
+}
+
+// IsOnFrequency implements Client.IsOnFrequency.
+func (c *client) IsOnFrequency(unitID uint32) bool {
+	return c.dataClient.IsOnFrequency(unitID)
 }

--- a/pkg/synthesizer/speakers/piper.go
+++ b/pkg/synthesizer/speakers/piper.go
@@ -10,7 +10,6 @@ import (
 	"github.com/dharmab/skyeye/pkg/pcm"
 	"github.com/dharmab/skyeye/pkg/synthesizer/voices"
 	"github.com/nabbl/piper"
-	"github.com/rs/zerolog/log"
 	"github.com/zaf/resample"
 )
 
@@ -58,10 +57,9 @@ func downsample(in []byte, orignalRate float64, newRate float64, channels int) (
 	}
 	defer resampler.Close()
 
-	n, err := resampler.Write(in)
+	_, err = resampler.Write(in)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resample synthesized audio: %w", err)
 	}
-	log.Debug().Int("originalRate", int(orignalRate)).Int("newRate", int(newRate)).Int("length", n).Msg("resampled synthesized audio")
 	return buf.Bytes(), nil
 }


### PR DESCRIPTION
Implement a THREAT call system.

The radar has a new Threats method which returns a map of the hostile coalition's groups to UnitIDs they currently threaten.  Threat criteria is currently placeholder: within 35 NM, or within 100 NM and aspect Hot towards the unit.

The controller calls the Threat method every ten seconds. It iterates over the threats and checks if it's issued a call for that threat recently (it has a data structure tracking cooldown timers for each hostile group).

The controller now has a reference to the SRS client so it can check if a unit is on the bot's frequency before issuing a call.