### PR TITLE
Use scaled threat ranges to compare threat level

### DIFF
--- a/pkg/encyclopedia/encyclopedia.go
+++ b/pkg/encyclopedia/encyclopedia.go
@@ -1,2 +1,0 @@
-// package encyclopedia is a database of aircraft data
-package encyclopedia

--- a/pkg/radar/center.go
+++ b/pkg/radar/center.go
@@ -24,7 +24,7 @@ func (s *scope) updateCenterPoint() {
 	for itr.next() {
 		contact := itr.value()
 		data, ok := encyclopedia.GetAircraftData(contact.Contact.ACMIName)
-		isArmed := !ok || data.ThreatFactor() > 0
+		isArmed := !ok || data.ThreatRadius() > 0
 		isValid := isValidTrack(contact)
 		if isArmed && isValid {
 			contactLocation := contact.LastKnown().Point

--- a/pkg/radar/group.go
+++ b/pkg/radar/group.go
@@ -207,6 +207,18 @@ func (g *group) category() brevity.ContactCategory {
 	return aircraft.Category()
 }
 
+func (g *group) isFighter() bool {
+	isFighter := false
+	for _, trackfile := range g.contacts {
+		data, ok := encyclopedia.GetAircraftData(trackfile.Contact.ACMIName)
+		if ok && data.HasTag(encyclopedia.Fighter) {
+			isFighter = true
+			break
+		}
+	}
+	return isFighter
+}
+
 // point returns the center point of the group
 func (g *group) point() orb.Point {
 	center := g.contacts[0].LastKnown().Point
@@ -227,17 +239,17 @@ func (g *group) missionTime() time.Time {
 	return latest
 }
 
-// threatFactor returns the highest threat factor of all contacts in the group
-func (g *group) threatFactor() float64 {
-	highest := 0.0
+// threatRadius returns the highest threat radius of all contacts in the group
+func (g *group) threatRadius() unit.Length {
+	highest := unit.Length(0)
 	for _, trackfile := range g.contacts {
 		data, ok := encyclopedia.GetAircraftData(trackfile.Contact.ACMIName)
 		if !ok {
-			highest = encyclopedia.DefaultThreat
+			highest = encyclopedia.DefaultThreatRadius
 		}
-		factor := data.ThreatFactor()
-		if factor > highest {
-			highest = factor
+		radius := data.ThreatRadius()
+		if radius > highest {
+			highest = radius
 		}
 	}
 	return highest


### PR DESCRIPTION
Replace each aircraft's threat factor with a threat radius. The radius is easier to use in THREAT calls (#154) because it allows us to more easily scale the threat based on distance to arbitrary points.

Replace the PICTURE threat ranking algorithm. Before:

1. Armed over unarmed
2. Planes over helicopters
3. Mixture of distance, threat factor, altitude and size.

After:

1. Armed over unarmed
2. Planes over helicopters
3. Fighters, if they're inside the threat radius for their platform, over all others
4. Ratio of distance to threat radius for the platform, within 3NM margin
5. Distance, within 3NM margin
6. Altitude (pretty rare to make it this far - essentially need multiple groups of the same class of aircraft at the same distance)