### PR TITLE
Implement altitude stacks

### DIFF
--- a/pkg/brevity/altitude.go
+++ b/pkg/brevity/altitude.go
@@ -1,0 +1,48 @@
+package brevity
+
+import (
+	"math"
+	"slices"
+
+	"github.com/martinlindhe/unit"
+)
+
+// Stack represents a single layer of an altitude STACK.
+type Stack struct {
+	Altitude unit.Length
+	Count    int
+}
+
+// Stacks creates altitude STACKS from altitudes.
+func Stacks(a ...unit.Length) []Stack {
+	for i, alt := range a {
+		a[i] = unit.Length(math.Round(alt.Feet()/1000)) * 1000 * unit.Foot
+	}
+	// reverse sort
+	slices.SortFunc(a, func(i, j unit.Length) int {
+		if i < j {
+			return -1
+		}
+		if i > j {
+			return 1
+		}
+		return 0
+	})
+
+	stacks := []Stack{}
+	for i := len(a) - 1; i >= 0; i-- {
+		if len(stacks) == 0 {
+			stacks = append(stacks, Stack{Altitude: a[i], Count: 1})
+		} else {
+			j := len(stacks) - 1
+			highest := stacks[j].Altitude
+			if a[i] <= highest-9900*unit.Foot {
+				stacks = append(stacks, Stack{Altitude: a[i], Count: 1})
+			} else {
+				stacks[j].Count++
+			}
+		}
+	}
+
+	return stacks
+}

--- a/pkg/brevity/altitude_test.go
+++ b/pkg/brevity/altitude_test.go
@@ -1,0 +1,46 @@
+package brevity
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/martinlindhe/unit"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStacks(t *testing.T) {
+	tests := []struct {
+		input    []unit.Length
+		expected []Stack
+	}{
+		{
+			input:    []unit.Length{unit.Foot * 10000, unit.Foot * 20000, unit.Foot * 30000, unit.Foot * 40000, unit.Foot * 50000},
+			expected: []Stack{{Altitude: unit.Foot * 50000, Count: 1}, {Altitude: unit.Foot * 40000, Count: 1}, {Altitude: unit.Foot * 30000, Count: 1}, {Altitude: unit.Foot * 20000, Count: 1}, {Altitude: unit.Foot * 10000, Count: 1}},
+		},
+		{
+			input:    []unit.Length{unit.Foot * 10000, unit.Foot * 10000},
+			expected: []Stack{{Altitude: unit.Foot * 10000, Count: 2}},
+		},
+		{
+			input:    []unit.Length{unit.Foot * 10000, unit.Foot * 15000},
+			expected: []Stack{{Altitude: unit.Foot * 15000, Count: 2}},
+		},
+		{
+			input:    []unit.Length{unit.Foot * 10000, unit.Foot * 20000, unit.Foot * 20000},
+			expected: []Stack{{Altitude: unit.Foot * 20000, Count: 2}, {Altitude: unit.Foot * 10000, Count: 1}},
+		},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			stacks := Stacks(test.input...)
+			for i, stack := range stacks {
+				expectedStack := test.expected[i]
+				log.Trace().Float64("expected", float64(expectedStack.Altitude)).Float64("actual", float64(stack.Altitude)).Msg("checking altitudes")
+				assert.Equal(t, expectedStack.Altitude, stack.Altitude)
+				log.Trace().Int("expected", expectedStack.Count).Int("actual", stack.Count).Msg("checking counts")
+				assert.Equal(t, expectedStack.Count, stack.Count)
+			}
+		})
+	}
+}

--- a/pkg/brevity/group.go
+++ b/pkg/brevity/group.go
@@ -20,8 +20,11 @@ type Group interface {
 	Contacts() int
 	// Bullseye is the location of the group. This may be nil for BOGEY DOPE, SNAPLOCK, and THREAT calls.
 	Bullseye() *Bullseye
-	// Altitude is the group's altitude above sea level. This may be nil for BOGEY DOPE, SNAPLOCK, and THREAT calls.
+	// Altitude is the group's highest altitude. This may be zero for BOGEY DOPE, SNAPLOCK, and THREAT calls.
 	Altitude() unit.Length
+	// Stacks are the group's altitude STACKS, ordered from highest to lowest in intervals of at least 10,000 feet.
+	// This may be empty for BOGEY DOPE, SNAPLOCK, and THREAT calls.
+	Stacks() []Stack
 	// Track is the group's track direction. This may be UnknownDirection for BOGEY DOPE, SNAPLOCK, and THREAT calls.
 	Track() Track
 	// Aspect is the group's aspect angle relative to another aircraft. This may be nil for BOGEY DOPE, SNAPLOCK, and some THREAT calls.
@@ -34,7 +37,7 @@ type Group interface {
 	SetDeclaration(Declaration)
 	// Heavy is true if the group contacts 3 or more contacts.
 	Heavy() bool
-	// Platforms is the NATO reporting names of the group's aircraft platforms (for Soviet/Russian/Chinese aircraft) or
+	// Platforms are the NATO reporting names of the group's aircraft platforms (for Soviet/Russian/Chinese aircraft) or
 	// alternative names for other aircraft. Skyeye supports mixed-platform groups, so this returns multiple values.
 	Platforms() []string
 	// High is true if the aircraft altitude is above 40,000 feet.
@@ -45,5 +48,6 @@ type Group interface {
 	VeryFast() bool
 	// String returns a human-readable description of the group.
 	String() string
+	// UnitIDs returns the unit IDs of all contacts in the group.
 	UnitIDs() []uint32
 }

--- a/pkg/radar/nearby.go
+++ b/pkg/radar/nearby.go
@@ -48,9 +48,8 @@ func (s *scope) FindNearbyGroupsWithBRAA(origin, interest orb.Point, minAltitude
 			) * unit.Degree,
 		).Magnetic(s.Declination(origin))
 		_range := unit.Length(math.Abs(geo.Distance(origin, grp.point())))
-		altitude := grp.Altitude()
 		aspect := brevity.AspectFromAngle(bearing, grp.course())
-		grp.braa = brevity.NewBRAA(bearing, _range, altitude, aspect)
+		grp.braa = brevity.NewBRAA(bearing, _range, grp.altitudes(), aspect)
 		grp.bullseye = nil
 
 		result = append(result, grp)

--- a/pkg/radar/nearest.go
+++ b/pkg/radar/nearest.go
@@ -80,12 +80,11 @@ func (s *scope) FindNearestGroupWithBRAA(
 		) * unit.Degree,
 	).Magnetic(declination)
 	_range := unit.Length(geo.Distance(origin, grp.point())) * unit.Meter
-	altitude := trackfile.LastKnown().Altitude
 	aspect := brevity.AspectFromAngle(bearing, trackfile.Course())
 	grp.braa = brevity.NewBRAA(
 		bearing,
 		_range,
-		altitude,
+		grp.altitudes(),
 		aspect,
 	)
 	grp.bullseye = nil
@@ -178,7 +177,7 @@ func (s *scope) FindNearestGroupInSector(origin orb.Point, minAltitude, maxAltit
 	grp.braa = brevity.NewBRAA(
 		preciseBearing,
 		_range,
-		grp.Altitude(),
+		grp.altitudes(),
 		grp.Aspect(),
 	)
 	logger.Debug().Str("group", grp.String()).Msg("determined nearest group")

--- a/pkg/radar/threat.go
+++ b/pkg/radar/threat.go
@@ -51,7 +51,7 @@ func (s *scope) Threats(coalition coalitions.Coalition) map[brevity.Group][]uint
 			).Magnetic(s.Declination(trackfile.LastKnown().Point))
 			_range := unit.Length(geo.Distance(trackfile.LastKnown().Point, grp.point()))
 			aspect := brevity.AspectFromAngle(bearing, grp.course())
-			grp.braa = brevity.NewBRAA(bearing, _range, grp.Altitude(), aspect)
+			grp.braa = brevity.NewBRAA(bearing, _range, grp.altitudes(), aspect)
 			grp.bullseye = nil
 		}
 	}


### PR DESCRIPTION
Fixes #55.

Groups, BRA and BRAA now stores multiple altitudes. A new type called Stack organizes these altitudes into contact sub-groupings spaced 10,000 feet apart.

Groupings now span an unlimited vertical height, but also now check if the aircraft share one of the tags Fighter, Attack or Unarmed (if defined).