### PR TITLE
Remove go.alternateTools setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,6 @@
         "LIBRARY_PATH": "${workspaceFolder}/third_party/whisper.cpp/",
         "GOROOT": "c:\\msys64\\mingw64\\lib\\go",
     },
-    "go.alternateTools": {
-        "go": "c:\\msys64\\mingw64\\bin\\go.exe",
-    },
     "logViewer.watch": [
         {
             "title": "DCS SRS Server Log",


### PR DESCRIPTION
For some reason this broke my intellisense after 1.23 upgrade