### PR TITLE
Separate SRS and TacView IDs

### DIFF
--- a/docs/PLAYER.md
+++ b/docs/PLAYER.md
@@ -287,7 +287,7 @@ The GCI controller monitors for threats which are near or approaching friendly a
 
 Threat locations are given in BRAA format if they are relevant to a single friendly aircraft, or Bullseye calls if they are relevant to multiple friendly aircraft.
 
-Your own aircraft must be on the SRS frequency to receive THREAT monitoring.
+Your own aircraft must be on the SRS frequency, and using the same name in DCS and in SRS, to receive THREAT monitoring.
 
 ### FADED
 

--- a/pkg/brevity/group.go
+++ b/pkg/brevity/group.go
@@ -48,6 +48,6 @@ type Group interface {
 	VeryFast() bool
 	// String returns a human-readable description of the group.
 	String() string
-	// UnitIDs returns the unit IDs of all contacts in the group.
-	UnitIDs() []uint32
+	// ObjectIDs returns the object IDs of all contacts in the group.
+	ObjectIDs() []uint64
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -88,8 +88,8 @@ func (c *controller) Run(ctx context.Context, out chan<- any) {
 
 	log.Info().Msg("attaching FADED callback")
 	c.scope.SetFadedCallback(func(group brevity.Group, coalition coalitions.Coalition) {
-		for _, id := range group.UnitIDs() {
-			c.threatCooldowns.remove(uint32(id))
+		for _, id := range group.ObjectIDs() {
+			c.threatCooldowns.remove(id)
 		}
 		if coalition == c.coalition.Opposite() {
 			group.SetDeclaration(brevity.Hostile)
@@ -98,7 +98,7 @@ func (c *controller) Run(ctx context.Context, out chan<- any) {
 		}
 	})
 
-	log.Info().Int("frequency", int(c.frequency.Megahertz())).Msg("broadcasting SUNRISE call")
+	log.Info().Float64("frequency", c.frequency.Megahertz()).Msg("broadcasting SUNRISE call")
 	c.out <- brevity.SunriseCall{Frequency: c.frequency}
 
 	ticker := time.NewTicker(10 * time.Second)

--- a/pkg/radar/contacts_test.go
+++ b/pkg/radar/contacts_test.go
@@ -15,7 +15,7 @@ import (
 func TestGetByCallsign(t *testing.T) {
 	db := newContactDatabase()
 	trackfile := trackfiles.NewTrackfile(trackfiles.Labels{
-		UnitID:    1,
+		ID:        1,
 		Name:      "Mobius 1 Reaper",
 		Coalition: coalitions.Blue,
 		ACMIName:  "F-15C",
@@ -54,7 +54,7 @@ func TestRealCallsigns(t *testing.T) {
 
 	for i, test := range testCases {
 		trackfile := trackfiles.NewTrackfile(trackfiles.Labels{
-			UnitID:    uint32(i),
+			ID:        uint64(i),
 			Name:      test.Name,
 			Coalition: coalitions.Blue,
 			ACMIName:  "F-15C",
@@ -68,39 +68,39 @@ func TestRealCallsigns(t *testing.T) {
 		foundCallsign, tf, ok := db.getByCallsignAndCoalititon(test.heardAs, coalitions.Blue)
 		require.True(t, ok, "queried %s, expected %s, but result was %v", test.heardAs, test.Name, ok)
 		require.Equal(t, parsedCallsign, foundCallsign)
-		require.EqualValues(t, uint32(i), tf.Contact.UnitID)
+		require.EqualValues(t, uint64(i), tf.Contact.ID)
 	}
 }
 
-func TestGetByUnitID(t *testing.T) {
+func TestGetByID(t *testing.T) {
 	db := newContactDatabase()
 	trackfile := trackfiles.NewTrackfile(trackfiles.Labels{
-		UnitID:    1,
+		ID:        1,
 		Name:      "Mobius 1 Reaper",
 		Coalition: coalitions.Blue,
 		ACMIName:  "F-15C",
 	})
 	db.set(trackfile)
 
-	val, ok := db.getByUnitID(1)
+	val, ok := db.getByID(1)
 	require.True(t, ok)
 	require.EqualValues(t, trackfile, val)
 
-	_, ok = db.getByUnitID(2)
+	_, ok = db.getByID(2)
 	require.False(t, ok)
 }
 
 func TestSet(t *testing.T) {
 	database := newContactDatabase()
 	trackfile := trackfiles.NewTrackfile(trackfiles.Labels{
-		UnitID:    1,
+		ID:        1,
 		Name:      "Mobius 1 Reaper",
 		Coalition: coalitions.Blue,
 		ACMIName:  "F-15C",
 	})
 	database.set(trackfile)
 
-	val, ok := database.getByUnitID(1)
+	val, ok := database.getByID(1)
 	require.True(t, ok)
 	require.EqualValues(t, trackfile, val)
 
@@ -116,7 +116,7 @@ func TestSet(t *testing.T) {
 
 	database.set(trackfile)
 
-	val, ok = database.getByUnitID(1)
+	val, ok = database.getByID(1)
 	require.True(t, ok)
 	require.EqualValues(t, trackfile, val)
 }
@@ -124,20 +124,20 @@ func TestSet(t *testing.T) {
 func TestDelete(t *testing.T) {
 	database := newContactDatabase()
 	trackfile := trackfiles.NewTrackfile(trackfiles.Labels{
-		UnitID:    1,
+		ID:        1,
 		Name:      "Mobius 1 Reaper",
 		Coalition: coalitions.Blue,
 		ACMIName:  "F-15C",
 	})
 	database.set(trackfile)
 
-	_, ok := database.getByUnitID(1)
+	_, ok := database.getByID(1)
 	require.True(t, ok)
 
 	ok = database.delete(1)
 	require.True(t, ok)
 
-	_, ok = database.getByUnitID(1)
+	_, ok = database.getByID(1)
 	require.False(t, ok)
 
 	ok = database.delete(2)
@@ -148,7 +148,7 @@ func TestValues(t *testing.T) {
 	db := newContactDatabase()
 
 	mobius := trackfiles.NewTrackfile(trackfiles.Labels{
-		UnitID:    1,
+		ID:        1,
 		Name:      "Mobius 1 Reaper",
 		Coalition: coalitions.Blue,
 		ACMIName:  "F-15C",
@@ -156,7 +156,7 @@ func TestValues(t *testing.T) {
 	db.set(mobius)
 
 	yellow := trackfiles.NewTrackfile(trackfiles.Labels{
-		UnitID:    2,
+		ID:        2,
 		Name:      "Yellow 13 Reiher",
 		Coalition: coalitions.Red,
 		ACMIName:  "Su-27",
@@ -166,10 +166,10 @@ func TestValues(t *testing.T) {
 	foundMobius := false
 	foundYellow := false
 	for trackfile := range db.values() {
-		if trackfile.Contact.UnitID == mobius.Contact.UnitID {
+		if trackfile.Contact.ID == mobius.Contact.ID {
 			require.EqualValues(t, mobius, trackfile)
 			foundMobius = true
-		} else if trackfile.Contact.UnitID == yellow.Contact.UnitID {
+		} else if trackfile.Contact.ID == yellow.Contact.ID {
 			require.EqualValues(t, yellow, trackfile)
 			foundYellow = true
 		}

--- a/pkg/radar/faded.go
+++ b/pkg/radar/faded.go
@@ -10,7 +10,7 @@ import (
 
 func isTrackfileInGroup(trackfile *trackfiles.Trackfile, grp *group) bool {
 	for _, contact := range grp.contacts {
-		if contact.Contact.UnitID == trackfile.Contact.UnitID {
+		if contact.Contact.ID == trackfile.Contact.ID {
 			return true
 		}
 	}
@@ -53,7 +53,7 @@ func (s *scope) handleFaded(fades []sim.Faded) {
 	var groups []group
 	for _, fade := range fades {
 		// Find the trackfile for the faded contact
-		trackfile, ok := s.contacts.getByUnitID(fade.UnitID)
+		trackfile, ok := s.contacts.getByID(fade.ID)
 		if !ok {
 			continue
 		}
@@ -77,7 +77,7 @@ func (s *scope) handleFaded(fades []sim.Faded) {
 
 	// remove the faded contacts from the database
 	for _, fade := range fades {
-		s.contacts.delete(fade.UnitID)
+		s.contacts.delete(fade.ID)
 	}
 
 	// call the faded callback for each group

--- a/pkg/radar/group.go
+++ b/pkg/radar/group.go
@@ -261,10 +261,10 @@ func (g *group) threatRadius() unit.Length {
 	return highest
 }
 
-func (g *group) UnitIDs() []uint32 {
-	unitIDs := make([]uint32, 0, len(g.contacts))
+func (g *group) ObjectIDs() []uint64 {
+	ids := make([]uint64, 0, len(g.contacts))
 	for _, trackfile := range g.contacts {
-		unitIDs = append(unitIDs, trackfile.Contact.UnitID)
+		ids = append(ids, trackfile.Contact.ID)
 	}
-	return unitIDs
+	return ids
 }

--- a/pkg/radar/grouping.go
+++ b/pkg/radar/grouping.go
@@ -11,13 +11,13 @@ import (
 )
 
 func (s *scope) enumerateGroups(coalition coalitions.Coalition) []*group {
-	visited := make(map[uint32]struct{})
+	visited := make(map[uint64]struct{})
 	groups := make([]*group, 0)
 	for trackfile := range s.contacts.values() {
-		if _, ok := visited[trackfile.Contact.UnitID]; ok {
+		if _, ok := visited[trackfile.Contact.ID]; ok {
 			continue
 		}
-		visited[trackfile.Contact.UnitID] = struct{}{}
+		visited[trackfile.Contact.ID] = struct{}{}
 
 		if trackfile.Contact.Coalition != coalition {
 			continue
@@ -31,8 +31,8 @@ func (s *scope) enumerateGroups(coalition coalitions.Coalition) []*group {
 		if grp == nil {
 			continue
 		}
-		for _, unitID := range grp.UnitIDs() {
-			visited[unitID] = struct{}{}
+		for _, id := range grp.ObjectIDs() {
+			visited[id] = struct{}{}
 		}
 		groups = append(groups, grp)
 	}
@@ -74,7 +74,7 @@ func (s *scope) addNearbyAircraftToGroup(this *trackfiles.Trackfile, group *grou
 	spreadInterval := 5 * unit.NauticalMile
 	for other := range s.contacts.values() {
 		// Skip if this one is already in the group
-		if slices.Contains(group.UnitIDs(), other.Contact.UnitID) {
+		if slices.Contains(group.ObjectIDs(), other.Contact.ID) {
 			continue
 		}
 

--- a/pkg/radar/id.go
+++ b/pkg/radar/id.go
@@ -13,8 +13,8 @@ func (s *scope) FindCallsign(callsign string, coalition coalitions.Coalition) (s
 	return foundCallsign, tf
 }
 
-func (s *scope) FindUnit(unitId uint32) *trackfiles.Trackfile {
-	trackfile, ok := s.contacts.getByUnitID(unitId)
+func (s *scope) FindUnit(id uint64) *trackfiles.Trackfile {
+	trackfile, ok := s.contacts.getByID(id)
 	if !ok {
 		return nil
 	}

--- a/pkg/radar/nearby.go
+++ b/pkg/radar/nearby.go
@@ -12,9 +12,9 @@ import (
 func (s *scope) findNearbyGroups(pointOfInterest orb.Point, minAltitude, maxAltitude, radius unit.Length, coalition coalitions.Coalition, filter brevity.ContactCategory) []*group {
 	circle := geo.NewBoundAroundPoint(pointOfInterest, radius.Meters())
 	groups := make([]*group, 0)
-	visited := make(map[uint32]struct{})
+	visited := make(map[uint64]struct{})
 	for trackfile := range s.contacts.values() {
-		if _, ok := visited[trackfile.Contact.UnitID]; ok {
+		if _, ok := visited[trackfile.Contact.ID]; ok {
 			continue
 		}
 		isMatch := s.isMatch(trackfile, coalition, filter)
@@ -22,7 +22,7 @@ func (s *scope) findNearbyGroups(pointOfInterest orb.Point, minAltitude, maxAlti
 		inStack := minAltitude <= trackfile.LastKnown().Altitude && trackfile.LastKnown().Altitude <= maxAltitude
 		if isMatch && inCircle && inStack {
 			grp := s.findGroupForAircraft(trackfile)
-			for _, id := range grp.UnitIDs() {
+			for _, id := range grp.ObjectIDs() {
 				visited[id] = struct{}{}
 			}
 			groups = append(groups, grp)

--- a/pkg/radar/nearest.go
+++ b/pkg/radar/nearest.go
@@ -44,7 +44,7 @@ func (s *scope) FindNearestTrackfile(
 		log.Debug().
 			Any("origin", origin).
 			Str("aircraft", nearestTrackfile.Contact.ACMIName).
-			Int("unitID", int(nearestTrackfile.Contact.UnitID)).
+			Uint64("id", nearestTrackfile.Contact.ID).
 			Int("altitude", int(nearestTrackfile.LastKnown().Altitude.Feet())).
 			Msg("found nearest contact")
 	} else {
@@ -129,7 +129,7 @@ func (s *scope) FindNearestGroupInSector(origin orb.Point, minAltitude, maxAltit
 	nearestDistance := unit.Length(math.MaxFloat64)
 	var nearestContact *trackfiles.Trackfile
 	for trackfile := range s.contacts.values() {
-		logger := logger.With().Int("unitID", int(trackfile.Contact.UnitID)).Logger()
+		logger := logger.With().Int("id", int(trackfile.Contact.ID)).Logger()
 		isMatch := s.isMatch(trackfile, coalition, filter)
 		isWithinAltitude := minAltitude <= trackfile.LastKnown().Altitude && trackfile.LastKnown().Altitude <= maxAltitude
 		if isMatch && isWithinAltitude {
@@ -147,7 +147,7 @@ func (s *scope) FindNearestGroupInSector(origin orb.Point, minAltitude, maxAltit
 		return nil
 	}
 
-	logger = log.With().Int("unitID", int(nearestContact.Contact.UnitID)).Logger()
+	logger = log.With().Uint64("id", nearestContact.Contact.ID).Logger()
 	logger.Debug().Msg("found nearest contact")
 	grp := s.findGroupForAircraft(nearestContact)
 	if grp == nil {

--- a/pkg/radar/threat.go
+++ b/pkg/radar/threat.go
@@ -9,8 +9,8 @@ import (
 	"github.com/martinlindhe/unit"
 )
 
-func (s *scope) Threats(coalition coalitions.Coalition) map[brevity.Group][]uint32 {
-	threats := make(map[*group][]uint32)
+func (s *scope) Threats(coalition coalitions.Coalition) map[brevity.Group][]uint64 {
+	threats := make(map[*group][]uint64)
 	hostileGroups := s.enumerateGroups(coalition)
 	for _, grp := range hostileGroups {
 		friendlyGroups := s.findNearbyGroups(
@@ -23,7 +23,7 @@ func (s *scope) Threats(coalition coalitions.Coalition) map[brevity.Group][]uint
 		)
 
 		// Populate threats map with hostile-friendly relations that meet threat criteria.
-		unitIDs := make([]uint32, 0)
+		ids := make([]uint64, 0)
 		for _, friendlyGroup := range friendlyGroups {
 			distance := spatial.Distance(grp.point(), friendlyGroup.point())
 			withinThreatRadius := distance < grp.threatRadius() || distance < s.mandatoryThreatRadius
@@ -31,17 +31,17 @@ func (s *scope) Threats(coalition coalitions.Coalition) map[brevity.Group][]uint
 			friendlyIsPlane := friendlyGroup.category() == brevity.FixedWing
 			heloVersusPlane := hostileIsHelo && friendlyIsPlane
 			if withinThreatRadius && !heloVersusPlane {
-				unitIDs = append(unitIDs, friendlyGroup.UnitIDs()...)
+				ids = append(ids, friendlyGroup.ObjectIDs()...)
 			}
 		}
-		if len(unitIDs) == 0 {
+		if len(ids) == 0 {
 			continue
 		}
-		threats[grp] = unitIDs
+		threats[grp] = ids
 
 		// If the hostile group only threatens a single friendly unit, use BRAA instead of Bullseye.
 		if len(threats[grp]) == 1 {
-			trackfile, ok := s.contacts.getByUnitID(threats[grp][0])
+			trackfile, ok := s.contacts.getByID(threats[grp][0])
 			if !ok {
 				continue
 			}
@@ -54,9 +54,9 @@ func (s *scope) Threats(coalition coalitions.Coalition) map[brevity.Group][]uint
 		}
 	}
 
-	result := make(map[brevity.Group][]uint32)
-	for grp, unitIDs := range threats {
-		result[grp] = unitIDs
+	result := make(map[brevity.Group][]uint64)
+	for grp, ids := range threats {
+		result[grp] = ids
 	}
 	return result
 }

--- a/pkg/sim/sim.go
+++ b/pkg/sim/sim.go
@@ -38,6 +38,6 @@ type Faded struct {
 	Timestamp time.Time
 	// Mission time when the aircraft disappeared.
 	MissionTimestamp time.Time
-	// UnitID of the aircraft that disappeared.
-	UnitID uint32
+	// ID of the aircraft that disappeared.
+	ID uint64
 }

--- a/pkg/simpleradio/client.go
+++ b/pkg/simpleradio/client.go
@@ -26,8 +26,8 @@ type Client interface {
 	Receive() <-chan audio.Audio
 	// Transmit queues a transmission to send over the radio. The audio data should be in F32LE PCM format.
 	Transmit(audio.Audio)
-	// IsOnFrequency checks if the given unit ID is on the client's frequency.
-	IsOnFrequency(unitID uint32) bool
+	// IsOnFrequency checks if the named unit is on the client's frequency.
+	IsOnFrequency(string) bool
 }
 
 // client implements the SRS Client.
@@ -58,22 +58,22 @@ func NewClient(config types.ClientConfiguration) (Client, error) {
 	return client, nil
 }
 
-// Name implements Client.Name.
+// Name implements [Client.Name].
 func (c *client) Name() string {
 	return c.dataClient.Name()
 }
 
-// Frequency implements Client.Frequency.
+// Frequency implements [Client.Frequency].
 func (c *client) Frequency() float64 {
 	return c.audioClient.Frequency()
 }
 
-// FrequencyMHz implements Client.FrequencyMHz.
+// FrequencyMHz implements [Client.FrequencyMHz].
 func (c *client) FrequencyMHz() float64 {
 	return c.Frequency() / 1e6
 }
 
-// Run implements Client.Run.
+// Run implements [Client.Run].
 func (c *client) Run(ctx context.Context, wg *sync.WaitGroup) error {
 	errorChan := make(chan error)
 
@@ -109,17 +109,17 @@ func (c *client) Run(ctx context.Context, wg *sync.WaitGroup) error {
 	}
 }
 
-// Receive implements Client.Receive.
+// Receive implements [Client.Receive].
 func (c *client) Receive() <-chan audio.Audio {
 	return c.audioClient.Receive()
 }
 
-// Transmit implements Client.Transmit.
+// Transmit implements [Client.Transmit].
 func (c *client) Transmit(sample audio.Audio) {
 	c.audioClient.Transmit(sample)
 }
 
-// IsOnFrequency implements Client.IsOnFrequency.
-func (c *client) IsOnFrequency(unitID uint32) bool {
-	return c.dataClient.IsOnFrequency(unitID)
+// IsOnFrequency implements [Client.IsOnFrequency].
+func (c *client) IsOnFrequency(name string) bool {
+	return c.dataClient.IsOnFrequency(name)
 }

--- a/pkg/tacview/types/metadata.go
+++ b/pkg/tacview/types/metadata.go
@@ -21,7 +21,7 @@ func ParseTimeFrame(line string) (time.Duration, error) {
 }
 
 type ObjectUpdate struct {
-	ID         int
+	ID         uint64
 	IsGlobal   bool
 	IsRemoval  bool
 	Properties map[string]string
@@ -38,14 +38,14 @@ func ParseObjectUpdate(line string) (*ObjectUpdate, error) {
 	}
 
 	idStr, propertiesStr, _ := strings.Cut(line, ",")
-	id, err := strconv.ParseInt(idStr, 16, 64)
+	id, err := strconv.ParseUint(idStr, 16, 64)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing object ID: %w", err)
 	}
 	if id > math.MaxInt {
 		return nil, fmt.Errorf("object ID is too large: %d", id)
 	}
-	update.ID = int(id)
+	update.ID = id
 	if id == GlobalObjectID {
 		update.IsGlobal = true
 	}

--- a/pkg/tacview/types/object.go
+++ b/pkg/tacview/types/object.go
@@ -14,12 +14,12 @@ import (
 )
 
 type Object struct {
-	ID         int
+	ID         uint64
 	properties map[string]string
 	mut        sync.Mutex
 }
 
-func NewObject(id int) *Object {
+func NewObject(id uint64) *Object {
 	return &Object{
 		ID:         id,
 		properties: make(map[string]string),
@@ -78,7 +78,7 @@ func (o *Object) GetCoordinates(ref orb.Point) (*Coordinates, error) {
 	}
 	fields := strings.Split(val, "|")
 
-	logger := log.With().Int("id", o.ID).Str("transform", val).Logger()
+	logger := log.With().Uint64("id", o.ID).Str("transform", val).Logger()
 	if len(fields) < 3 {
 		logger.Trace().Msg("unexpected number of fields in coordinate transformation")
 		return nil, nil

--- a/pkg/trackfiles/trackfile.go
+++ b/pkg/trackfiles/trackfile.go
@@ -18,8 +18,8 @@ import (
 
 // Labels are identifying information attached to a trackfile.
 type Labels struct {
-	// UnitID is the in-game ID.
-	UnitID uint32
+	// ID is the object ID from TacView.
+	ID uint64
 	// Name is a unique string for each aircraft.
 	// If this is a player's aircraft, it will be the player's in-game name.
 	Name string
@@ -64,7 +64,7 @@ func (t *Trackfile) String() string {
 	point := t.LastKnown().Point
 	return fmt.Sprintf(
 		"%d %s (%f.3, %f.3) %f.0 ft %f.0 kts %q",
-		t.Contact.UnitID,
+		t.Contact.ID,
 		t.Contact.ACMIName,
 		point.Lon(),
 		point.Lat(),

--- a/pkg/trackfiles/trackfile_test.go
+++ b/pkg/trackfiles/trackfile_test.go
@@ -151,7 +151,7 @@ func TestTracking(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			trackfile := NewTrackfile(Labels{
-				UnitID:    1,
+				ID:        1,
 				ACMIName:  "F-15C",
 				Name:      "Eagle 1",
 				Coalition: coalitions.Blue,


### PR DESCRIPTION
DCS/SRS and TacView IDs are separate domains and can't be directly compared. Split their usage up. If we need to check if someone is on SRS, best-guess by comparing the in-game name to the client name instead.

Fixes #218 