### PR TITLE
Implement MERGED calls

### DIFF
--- a/docs/PLAYER.md
+++ b/docs/PLAYER.md
@@ -294,11 +294,17 @@ Requesting a PICTURE will reset the interval on any automatic broadcast.
 
 ### THREAT
 
-The GCI controller monitors for threats which are near or approaching friendly aircraft. Any hostile aircraft within a pre-briefed range (default 25NM) is always considered a threat. At further ranges, the bandit's aircraft capabilities are also considered. Threat calls are broadcast every few minutes for as long as the threat criteria are met.
+The GCI controller monitors for threats which are near or approaching friendly aircraft. Any hostile aircraft within a pre-briefed range (default 25NM) is always considered a threat. At further ranges, the bandit's aircraft capabilities are also considered. Threat calls are broadcast every few minutes for as long as the threat criteria are met. THREAT calls about rotary-wing threats are only broadcast to other rotary-wing aircraft. A plane won't receive warnings about helicopter threats.
 
 Threat locations are given in BRAA format if they are relevant to a single friendly aircraft, or in bullseye format if they are relevant to multiple friendly aircraft.
 
 Your own aircraft must be on a SkyEye SRS frequency, and using the same name in DCS and in SRS, to receive THREAT monitoring.
+
+### MERGED
+
+If a fixed-wing threat closes within 3 nautical miles of a friendly aircraft, the controller will transmit a MERGED call. MERGED calls only apply to fixed-wing threats. You won't receive a MERGED call about a helicopter threat.
+
+Your own aircraft must be on the SRS frequency, and using the same name in DCS and in SRS, to receive MERGED calls.
 
 ### FADED
 

--- a/internal/application/app.go
+++ b/internal/application/app.go
@@ -123,9 +123,9 @@ func NewApplication(ctx context.Context, config conf.Configuration) (Application
 	rdr := radar.New(config.Coalition, updates, fades, config.MandatoryThreatRadius)
 	log.Info().Msg("constructing GCI controller")
 	controller := controller.New(
-		rdr, srsClient,
+		rdr,
+		srsClient,
 		config.Coalition,
-		config.SRSFrequencies,
 		config.PictureBroadcastInterval,
 		config.EnableThreatMonitoring,
 		config.ThreatMonitoringInterval,
@@ -408,6 +408,9 @@ func (a *app) compose(ctx context.Context, in <-chan any, out chan<- composer.Na
 			case brevity.ThreatCall:
 				logger.Debug().Msg("composing THREAT call")
 				response = a.composer.ComposeThreatCall(c)
+			case brevity.MergedCall:
+				logger.Debug().Msg("composing MERGED call")
+				response = a.composer.ComposeMergedCall(c)
 			case brevity.SayAgainResponse:
 				logger.Debug().Msg("composing SAY AGAIN call")
 				response = a.composer.ComposeSayAgainResponse(c)

--- a/pkg/brevity/group.go
+++ b/pkg/brevity/group.go
@@ -46,6 +46,10 @@ type Group interface {
 	Fast() bool
 	// VeryFast is true is the group's speed is above 900kts ground speed or 1.5 Mach.
 	VeryFast() bool
+	// MergedWith is the number of friendlies this group is merged with.
+	MergedWith() int
+	// SetMergedWith sets the number of friendlies this group is merged with.
+	SetMergedWith(int)
 	// String returns a human-readable description of the group.
 	String() string
 	// ObjectIDs returns the object IDs of all contacts in the group.

--- a/pkg/brevity/merged.go
+++ b/pkg/brevity/merged.go
@@ -1,0 +1,19 @@
+package brevity
+
+import (
+	"github.com/martinlindhe/unit"
+)
+
+type MergedCall struct {
+	// Callsigns of the friendly aircraft in the merge.
+	Callsigns []string
+	// Hostile contacts that are merging with the friendly aircraft.
+	Group Group
+}
+
+const (
+	// MergeEntryDistance is the distance at which contacts are considered to enter the merge.
+	MergeEntryDistance = 3 * unit.NauticalMile
+	// MergeExitDistance is the distance at which contacts are considered to exit the merge.
+	MergeExitDistance = 5 * unit.NauticalMile
+)

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -30,6 +30,8 @@ type Composer interface {
 	ComposeSunriseCall(brevity.SunriseCall) NaturalLanguageResponse
 	// ComposeThreatCall constructs natural language brevity for announcing a threat.
 	ComposeThreatCall(brevity.ThreatCall) NaturalLanguageResponse
+	// ComposeMergedCall constructs natural language brevity for announcing a merge.
+	ComposeMergedCall(brevity.MergedCall) NaturalLanguageResponse
 	// ComposeSayAgainResponse constructs natural language brevity for asking a caller to repeat their last transmission.
 	ComposeSayAgainResponse(brevity.SayAgainResponse) NaturalLanguageResponse
 	// ComposeTripwireResponse constructs natural language brevity for educating a caller about threat monitoring.

--- a/pkg/composer/group.go
+++ b/pkg/composer/group.go
@@ -66,13 +66,20 @@ func (c *composer) ComposeGroup(group brevity.Group) NaturalLanguageResponse {
 		subtitle.WriteString(fmt.Sprintf("%s %s", label, braa.Subtitle))
 		isCardinalAspect := slices.Contains([]brevity.Aspect{brevity.Flank, brevity.Beam, brevity.Drag}, group.BRAA().Aspect())
 		isTrackKnown := group.Track() != brevity.UnknownDirection
-		if isCardinalAspect && isTrackKnown {
+		isFurball := group.Declaration() == brevity.Furball
+		if isCardinalAspect && isTrackKnown && !isFurball {
 			writeBoth(fmt.Sprintf(" %s", group.Track()))
 		}
 	}
 
 	// Declaration
 	writeBoth(fmt.Sprintf(", %s", group.Declaration()))
+	if group.MergedWith() == 1 {
+		writeBoth(", merged with 1 friendly")
+	}
+	if group.MergedWith() > 1 {
+		writeBoth(fmt.Sprintf(", merged with %d friendlies", group.MergedWith()))
+	}
 
 	// Fill-in information
 
@@ -109,6 +116,30 @@ func (c *composer) ComposeGroup(group brevity.Group) NaturalLanguageResponse {
 	}
 
 	writeBoth(". ")
+
+	return NaturalLanguageResponse{
+		Subtitle: subtitle.String(),
+		Speech:   speech.String(),
+	}
+}
+
+// ComposeMergedWithGroup is a short form of describing a group for use in merge calls.
+func (c *composer) ComposeMergedWithGroup(group brevity.Group) NaturalLanguageResponse {
+	var speech, subtitle strings.Builder
+	if group.Contacts() > 1 {
+		contacts := c.ComposeContacts(group.Contacts())
+		speech.WriteString(contacts.Speech + ", ")
+		subtitle.WriteString(contacts.Subtitle + ", ")
+	}
+
+	if group.MergedWith() > 0 {
+		mergedWith := " merged with 1 other friendly"
+		if group.MergedWith() > 1 {
+			mergedWith = fmt.Sprintf(" merged with %d other friendlies", group.MergedWith())
+		}
+		speech.WriteString(mergedWith)
+		subtitle.WriteString(mergedWith)
+	}
 
 	return NaturalLanguageResponse{
 		Subtitle: subtitle.String(),

--- a/pkg/composer/merged.go
+++ b/pkg/composer/merged.go
@@ -1,0 +1,19 @@
+package composer
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dharmab/skyeye/pkg/brevity"
+)
+
+func (c *composer) ComposeMergedCall(call brevity.MergedCall) NaturalLanguageResponse {
+	callsignList := strings.Join(call.Callsigns, ", ")
+	group := c.ComposeMergedWithGroup(call.Group)
+	template := "%s, merged. %s"
+
+	return NaturalLanguageResponse{
+		Subtitle: fmt.Sprintf(template, callsignList, group.Subtitle),
+		Speech:   fmt.Sprintf(template, callsignList, group.Speech),
+	}
+}

--- a/pkg/controller/bogeydope.go
+++ b/pkg/controller/bogeydope.go
@@ -39,6 +39,7 @@ func (c *controller) HandleBogeyDope(request *brevity.BogeyDopeRequest) {
 	}
 
 	nearestGroup.SetDeclaration(brevity.Hostile)
+	c.fillInMergeDetails(nearestGroup)
 
 	logger.Info().
 		Strs("platforms", nearestGroup.Platforms()).

--- a/pkg/controller/broadcast.go
+++ b/pkg/controller/broadcast.go
@@ -1,0 +1,30 @@
+package controller
+
+import (
+	"slices"
+
+	"github.com/dharmab/skyeye/pkg/parser"
+	"github.com/dharmab/skyeye/pkg/trackfiles"
+	"github.com/rs/zerolog/log"
+)
+
+func (c *controller) addFriendlyToBroadcast(callsigns []string, friendly *trackfiles.Trackfile) []string {
+	logger := log.With().Str("name", friendly.Contact.Name).Logger()
+	isOnFrequency := c.srsClient.IsOnFrequency(friendly.Contact.Name)
+	if isOnFrequency {
+		logger.Debug().Bool("isOnFrequency", isOnFrequency).Msg("friendly contact is on frequency")
+	}
+
+	shouldBroadcast := !c.threatMonitoringRequiresSRS || isOnFrequency
+	if !shouldBroadcast {
+		return callsigns
+	}
+	if callsign, ok := parser.ParsePilotCallsign(friendly.Contact.Name); ok {
+		if !slices.Contains(callsigns, callsign) {
+			callsigns = append(callsigns, callsign)
+		}
+	} else {
+		logger.Debug().Msg("could not parse callsign")
+	}
+	return callsigns
+}

--- a/pkg/controller/declare.go
+++ b/pkg/controller/declare.go
@@ -94,6 +94,9 @@ func (c *controller) HandleDeclare(request *brevity.DeclareRequest) {
 
 	if response.Group != nil {
 		response.Group.SetDeclaration(response.Declaration)
+		if response.Group.Declaration() == brevity.Hostile {
+			c.fillInMergeDetails(response.Group)
+		}
 	}
 
 	logger.Debug().Any("declaration", response.Declaration).Msg("responding to DECLARE request")

--- a/pkg/controller/merged.go
+++ b/pkg/controller/merged.go
@@ -1,1 +1,212 @@
 package controller
+
+import (
+	"maps"
+	"slices"
+	"sync"
+
+	"github.com/dharmab/skyeye/pkg/brevity"
+	"github.com/dharmab/skyeye/pkg/spatial"
+	"github.com/dharmab/skyeye/pkg/trackfiles"
+	"github.com/rs/zerolog/log"
+)
+
+// mergeTracker tracks hostile IDs and the friendly IDs they have merged with.
+type mergeTracker struct {
+	merged map[uint64]map[uint64]struct{}
+	lock   sync.RWMutex
+}
+
+func newMergeTracker() *mergeTracker {
+	return &mergeTracker{
+		merged: make(map[uint64]map[uint64]struct{}),
+	}
+}
+
+// merge records that the given hostile has merged with the given friendly.
+func (t *mergeTracker) merge(hostileID, friendID uint64) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	friendIDs, ok := t.merged[hostileID]
+	if !ok {
+		friendIDs = make(map[uint64]struct{})
+		t.merged[hostileID] = friendIDs
+	}
+	friendIDs[friendID] = struct{}{}
+}
+
+// isMerged checks if the given hostile has merged with the given friendly.
+func (t *mergeTracker) isMerged(hostileID, friendID uint64) bool {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	friendIDs, ok := t.merged[hostileID]
+	if !ok {
+		return false
+	}
+	_, ok = friendIDs[friendID]
+	return ok
+}
+
+// friendliesMergedWith returns the IDS that the given hostile ID is merged with.
+func (t *mergeTracker) friendliesMergedWith(hostileID uint64) []uint64 {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	friendIDs, ok := t.merged[hostileID]
+	if !ok {
+		return []uint64{}
+	}
+	return slices.Collect(maps.Keys(friendIDs))
+}
+
+// separate records that the given hostile and friendly IDs have exited the merge.
+func (t *mergeTracker) separate(hostileID, friendID uint64) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	friendIDs, ok := t.merged[hostileID]
+	if !ok {
+		return
+	}
+	delete(friendIDs, friendID)
+	if len(friendIDs) == 0 {
+		delete(t.merged, hostileID)
+	}
+}
+
+// remove removes the given ID from the merge tracker.
+func (t *mergeTracker) remove(id uint64) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	_, ok := t.merged[id]
+	if ok {
+		delete(t.merged, id)
+	} else {
+		for hostileID, friendIDs := range t.merged {
+			delete(friendIDs, id)
+			if len(friendIDs) == 0 {
+				delete(t.merged, hostileID)
+			}
+		}
+	}
+}
+
+// keep removes any IDs that are not in the given slice from the merge tracker.
+func (t *mergeTracker) keep(idsToKeep ...uint64) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	for id := range t.merged {
+		if !slices.Contains(idsToKeep, id) {
+			delete(t.merged, id)
+		}
+	}
+}
+
+// broadcastMerges updates the merge tracker and broadcasts merged calls for any new merges.
+func (c *controller) broadcastMerges() {
+	merges := c.scope.Merges(c.coalition)
+
+	hostileIDs := make([]uint64, 0)
+	for group := range merges {
+		hostileIDs = append(hostileIDs, group.ObjectIDs()...)
+	}
+	c.merges.keep(hostileIDs...)
+
+	for hostileGroup, friendlies := range merges {
+		newMergedFriendlies := c.updateMergesForGroup(hostileGroup, friendlies)
+
+		logger := log.With().Stringer("group", hostileGroup).Logger()
+		call := c.createMergedCall(hostileGroup, newMergedFriendlies)
+		if len(call.Callsigns) > 0 {
+			logger.Info().Strs("callsigns", call.Callsigns).Msg("broadcasting merged call")
+			c.out <- call
+		} else {
+			logger.Debug().Msg("skipping merged call because no relevant clients are on frequency")
+		}
+	}
+}
+
+// updateMergesForGroup updates the merge tracker for the given hostile group and friendly contacts.
+// Friendlies which are newly merged with the hostile group are returned.
+func (c *controller) updateMergesForGroup(hostileGroup brevity.Group, friendlies []*trackfiles.Trackfile) []*trackfiles.Trackfile {
+	friendIDs := make(map[uint64]struct{})
+	for _, friendly := range friendlies {
+		friendIDs[friendly.Contact.ID] = struct{}{}
+	}
+
+	newMergedFriendlies := make([]*trackfiles.Trackfile, 0)
+	for _, hostileID := range hostileGroup.ObjectIDs() {
+		for _, oldMergedFriendly := range c.merges.friendliesMergedWith(hostileID) {
+			if _, ok := friendIDs[oldMergedFriendly]; !ok {
+				c.merges.separate(hostileID, oldMergedFriendly)
+			}
+		}
+		hostile := c.scope.FindUnit(hostileID)
+		for _, friendly := range friendlies {
+			isNewMerge := c.updateMergesForContact(hostile, friendly)
+			if isNewMerge {
+				newMergedFriendlies = append(newMergedFriendlies, friendly)
+			}
+		}
+	}
+	return newMergedFriendlies
+}
+
+// updateMergesForContact checks if the given hostile and friendly have merged or separated, and updates the merge tracker accordingly.
+// It returns true if the contacts were merged, or false if they were already merged or if they were separated.
+func (c *controller) updateMergesForContact(hostile, friendly *trackfiles.Trackfile) bool {
+	logger := log.
+		With().
+		Str("hostile", hostile.Contact.Name).
+		Uint64("hostileID", hostile.Contact.ID).
+		Str("friendly", friendly.Contact.Name).
+		Uint64("friendID", friendly.Contact.ID).
+		Logger()
+
+	isMerged := c.merges.isMerged(hostile.Contact.ID, friendly.Contact.ID)
+	distance := spatial.Distance(friendly.LastKnown().Point, hostile.LastKnown().Point)
+	enteredMerge := distance < brevity.MergeEntryDistance
+	exitedMerge := distance > brevity.MergeExitDistance
+
+	if !isMerged && enteredMerge {
+		logger.Info().Msg("hostile and friendly merged")
+		c.merges.merge(hostile.Contact.ID, friendly.Contact.ID)
+		return true
+	} else if isMerged && exitedMerge {
+		logger.Info().Msg("hostile and friendly exited merge")
+		c.merges.separate(hostile.Contact.ID, friendly.Contact.ID)
+	} else if isMerged {
+		logger.Debug().Msg("hostile and friendly were already merged")
+	}
+	return false
+}
+
+func (c *controller) createMergedCall(hostileGroup brevity.Group, friendlies []*trackfiles.Trackfile) brevity.MergedCall {
+	call := brevity.MergedCall{
+		Group:     hostileGroup,
+		Callsigns: make([]string, 0),
+	}
+	for _, friendly := range friendlies {
+		call.Callsigns = c.addFriendlyToBroadcast(call.Callsigns, friendly)
+	}
+	return call
+}
+
+// fillInMergeDetails sets the group's merged-with count, and if it is greater than 0, declares the group to be a FURBALL.
+func (c *controller) fillInMergeDetails(group brevity.Group) {
+	mergedWith := 0
+	for _, id := range group.ObjectIDs() {
+		mergedWith += len(c.merges.friendliesMergedWith(id))
+	}
+	group.SetMergedWith(mergedWith)
+	if group.MergedWith() > 0 {
+		group.SetDeclaration(brevity.Furball)
+	}
+}
+
+func (c *controller) isGroupMergedWithFriendly(hostileGroup brevity.Group, friendID uint64) bool {
+	for _, hostileID := range hostileGroup.ObjectIDs() {
+		if c.merges.isMerged(hostileID, friendID) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/merged_test.go
+++ b/pkg/controller/merged_test.go
@@ -1,0 +1,110 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeTrackerMerge(t *testing.T) {
+	t.Parallel()
+	tracker := newMergeTracker()
+	tracker.merge(1, 2)
+	assert.True(t, tracker.isMerged(1, 2))
+	assert.False(t, tracker.isMerged(2, 1))
+	assert.False(t, tracker.isMerged(1, 3))
+	tracker.merge(1, 3)
+	assert.True(t, tracker.isMerged(1, 3))
+	tracker.merge(4, 1)
+	assert.True(t, tracker.isMerged(4, 1))
+}
+
+func TestMergeTrackerFriendliesMergedWith(t *testing.T) {
+	t.Parallel()
+	tracker := newMergeTracker()
+	tracker.merge(1, 2)
+	assert.Len(t, tracker.friendliesMergedWith(1), 1)
+	assert.Contains(t, tracker.friendliesMergedWith(1), uint64(2))
+	assert.Empty(t, tracker.friendliesMergedWith(3))
+	tracker.merge(1, 3)
+	assert.Len(t, tracker.friendliesMergedWith(1), 2)
+	assert.Contains(t, tracker.friendliesMergedWith(1), uint64(3))
+}
+
+func TestMergeTrackerSeparate(t *testing.T) {
+	t.Parallel()
+	tracker := newMergeTracker()
+	tracker.merge(1, 2)
+	tracker.merge(1, 3)
+	assert.True(t, tracker.isMerged(1, 2))
+	assert.True(t, tracker.isMerged(1, 3))
+	tracker.separate(1, 2)
+	assert.False(t, tracker.isMerged(1, 2))
+	assert.True(t, tracker.isMerged(1, 3))
+}
+
+func TestMergeTrackerRemove(t *testing.T) {
+	t.Parallel()
+	tracker := newMergeTracker()
+	red1 := uint64(1)
+	red2 := uint64(2)
+	red3 := uint64(3)
+	blue1 := uint64(11)
+	blue2 := uint64(12)
+	blue3 := uint64(13)
+
+	for _, hostile := range []uint64{red1, red2, red3} {
+		for _, friendly := range []uint64{blue1, blue2, blue3} {
+			tracker.merge(hostile, friendly)
+		}
+	}
+
+	assert.True(t, tracker.isMerged(red1, blue1))
+	assert.True(t, tracker.isMerged(red1, blue2))
+	assert.True(t, tracker.isMerged(red1, blue3))
+	assert.True(t, tracker.isMerged(red2, blue1))
+	assert.True(t, tracker.isMerged(red2, blue2))
+	assert.True(t, tracker.isMerged(red2, blue3))
+	assert.True(t, tracker.isMerged(red3, blue1))
+	assert.True(t, tracker.isMerged(red3, blue2))
+	assert.True(t, tracker.isMerged(red3, blue3))
+
+	// Remove a hostile ID
+	tracker.remove(red1)
+	assert.False(t, tracker.isMerged(red1, blue1))
+	assert.False(t, tracker.isMerged(red1, blue2))
+	assert.False(t, tracker.isMerged(red1, blue3))
+	assert.True(t, tracker.isMerged(red2, blue1))
+	assert.True(t, tracker.isMerged(red2, blue2))
+	assert.True(t, tracker.isMerged(red2, blue3))
+	assert.True(t, tracker.isMerged(red3, blue1))
+	assert.True(t, tracker.isMerged(red3, blue2))
+	assert.True(t, tracker.isMerged(red3, blue3))
+
+	// Remove a friendly ID
+	tracker.remove(blue1)
+	assert.False(t, tracker.isMerged(red1, blue1))
+	assert.False(t, tracker.isMerged(red1, blue2))
+	assert.False(t, tracker.isMerged(red1, blue3))
+	assert.False(t, tracker.isMerged(red2, blue1))
+	assert.True(t, tracker.isMerged(red2, blue2))
+	assert.True(t, tracker.isMerged(red2, blue3))
+	assert.False(t, tracker.isMerged(red3, blue1))
+	assert.True(t, tracker.isMerged(red3, blue2))
+	assert.True(t, tracker.isMerged(red3, blue3))
+}
+func TestMergeTrackerKeep(t *testing.T) {
+	t.Parallel()
+	tracker := newMergeTracker()
+	tracker.merge(1, 11)
+	tracker.merge(1, 12)
+	tracker.merge(2, 11)
+	tracker.merge(3, 12)
+	tracker.merge(4, 11)
+	tracker.keep(2, 4)
+	assert.False(t, tracker.isMerged(1, 11))
+	assert.False(t, tracker.isMerged(1, 12))
+	assert.True(t, tracker.isMerged(2, 11))
+	assert.False(t, tracker.isMerged(3, 12))
+	assert.True(t, tracker.isMerged(4, 11))
+}

--- a/pkg/controller/picture.go
+++ b/pkg/controller/picture.go
@@ -26,6 +26,7 @@ func (c *controller) broadcastPicture(logger *zerolog.Logger, forceBroadcast boo
 	isPictureClean := count == 0
 	for _, group := range groups {
 		group.SetDeclaration(brevity.Hostile)
+		c.fillInMergeDetails(group)
 	}
 
 	if c.wasLastPictureClean && isPictureClean && !forceBroadcast {

--- a/pkg/controller/snaplock.go
+++ b/pkg/controller/snaplock.go
@@ -83,6 +83,7 @@ func (c *controller) HandleSnaplock(request *brevity.SnaplockRequest) {
 
 	if response.Group != nil {
 		response.Group.SetDeclaration(response.Declaration)
+		c.fillInMergeDetails(response.Group)
 	}
 
 	c.out <- response

--- a/pkg/radar/callbacks.go
+++ b/pkg/radar/callbacks.go
@@ -3,12 +3,21 @@ package radar
 import (
 	"github.com/dharmab/skyeye/pkg/brevity"
 	"github.com/dharmab/skyeye/pkg/coalitions"
+	"github.com/dharmab/skyeye/pkg/trackfiles"
 )
 
 // FadedCallback is a callback function that is called when a group has not been updated by sensors for a timeout period.
-// The group and it's coalition are provided.
+// The group and its coalition are provided.
 type FadedCallback func(group brevity.Group, coalition coalitions.Coalition)
 
 func (s *scope) SetFadedCallback(callback FadedCallback) {
 	s.fadedCallback = callback
+}
+
+// RemovedCallback is a callback function that is called when a trackfile is aged out and removed.
+// A copy of the trackfile is provided.
+type RemovedCallback func(trackfile trackfiles.Trackfile)
+
+func (s *scope) SetRemovedCallback(callback RemovedCallback) {
+	s.removalCallback = callback
 }

--- a/pkg/radar/group.go
+++ b/pkg/radar/group.go
@@ -2,6 +2,7 @@ package radar
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -18,21 +19,22 @@ import (
 )
 
 type group struct {
-	isThreat     bool
-	contacts     []*trackfiles.Trackfile
-	bullseye     *orb.Point
-	braa         brevity.BRAA
-	aspect       *brevity.Aspect
-	declaraction brevity.Declaration
+	isThreat    bool
+	contacts    []*trackfiles.Trackfile
+	bullseye    *orb.Point
+	braa        brevity.BRAA
+	aspect      *brevity.Aspect
+	declaration brevity.Declaration
+	mergedWith  int
 }
 
 var _ brevity.Group = &group{}
 
 func newGroupUsingBullseye(bullseye orb.Point) *group {
 	return &group{
-		bullseye:     &bullseye,
-		contacts:     make([]*trackfiles.Trackfile, 0),
-		declaraction: brevity.Unable,
+		bullseye:    &bullseye,
+		contacts:    make([]*trackfiles.Trackfile, 0),
+		declaration: brevity.Unable,
 	}
 }
 
@@ -126,12 +128,12 @@ func (g *group) BRAA() brevity.BRAA {
 
 // Declaration implements [brevity.Group.Declaration].
 func (g *group) Declaration() brevity.Declaration {
-	return g.declaraction
+	return g.declaration
 }
 
 // SetDeclaration implements [brevity.Group.SetDeclaration].
 func (g *group) SetDeclaration(declaration brevity.Declaration) {
-	g.declaraction = declaration
+	g.declaration = declaration
 }
 
 // Heavy implements [brevity.Group.Heavy].
@@ -175,6 +177,16 @@ func (g *group) Fast() bool {
 // VeryFast implements [brevity.Group.VeryFast].
 func (g *group) VeryFast() bool {
 	return false
+}
+
+// MergedWith implements [brevity.Group.MergedWith].
+func (g *group) MergedWith() int {
+	return g.mergedWith
+}
+
+// SetMergedWith implements [brevity.Group.SetMergedWith].
+func (g *group) SetMergedWith(mergedWith int) {
+	g.mergedWith = mergedWith
 }
 
 func (g *group) String() string {
@@ -270,5 +282,6 @@ func (g *group) ObjectIDs() []uint64 {
 	for _, trackfile := range g.contacts {
 		ids = append(ids, trackfile.Contact.ID)
 	}
+	slices.Sort(ids)
 	return ids
 }

--- a/pkg/radar/grouping.go
+++ b/pkg/radar/grouping.go
@@ -3,6 +3,7 @@ package radar
 import (
 	"slices"
 
+	"github.com/dharmab/skyeye/pkg/brevity"
 	"github.com/dharmab/skyeye/pkg/coalitions"
 	"github.com/dharmab/skyeye/pkg/encyclopedia"
 	"github.com/dharmab/skyeye/pkg/spatial"
@@ -46,7 +47,11 @@ func (s *scope) findGroupForAircraft(trackfile *trackfiles.Trackfile) *group {
 		return nil
 	}
 	bullseye := s.Bullseye(trackfile.Contact.Coalition)
-	grp := newGroupUsingBullseye(bullseye)
+	grp := &group{
+		bullseye:    &bullseye,
+		contacts:    make([]*trackfiles.Trackfile, 0),
+		declaration: brevity.Unable,
+	}
 	grp.contacts = append(grp.contacts, trackfile)
 	s.addNearbyAircraftToGroup(trackfile, grp)
 	return grp

--- a/pkg/radar/merged.go
+++ b/pkg/radar/merged.go
@@ -1,0 +1,66 @@
+package radar
+
+import (
+	"maps"
+	"slices"
+
+	"github.com/dharmab/skyeye/pkg/brevity"
+	"github.com/dharmab/skyeye/pkg/coalitions"
+	"github.com/dharmab/skyeye/pkg/encyclopedia"
+	"github.com/dharmab/skyeye/pkg/spatial"
+	"github.com/dharmab/skyeye/pkg/trackfiles"
+)
+
+// Merges returns a map of fixed-wing groups on the opposing coalition to the contacts on the given coalition that they are merged with.
+func (s *scope) Merges(coalition coalitions.Coalition) map[brevity.Group][]*trackfiles.Trackfile {
+	visited := make(map[uint64]struct{})
+	merges := make(map[brevity.Group][]*trackfiles.Trackfile)
+	bullseye := s.Bullseye(coalition)
+	for contact := range s.contacts.values() {
+		if _, ok := visited[contact.Contact.ID]; ok {
+			continue
+		}
+
+		if contact.Contact.Coalition != coalition.Opposite() {
+			continue
+		}
+
+		// Exclude hostile helicopters
+		if data, ok := encyclopedia.GetAircraftData(contact.Contact.ACMIName); ok && data.Category() == brevity.RotaryWing {
+			continue
+		}
+
+		grp := s.findGroupForAircraft(contact)
+		mergedWith := make(map[uint64]*trackfiles.Trackfile)
+		for _, contact := range grp.contacts {
+			visited[contact.Contact.ID] = struct{}{}
+			for _, trackfile := range s.mergesForContact(contact) {
+				mergedWith[trackfile.Contact.ID] = trackfile
+			}
+		}
+		if len(mergedWith) == 0 {
+			continue
+		}
+		grp.isThreat = true
+		grp.bullseye = &bullseye
+		grp.declaration = brevity.Furball
+
+		merges[grp] = slices.Collect(maps.Values(mergedWith))
+	}
+	return merges
+}
+
+// mergesForContact returns the opposing trackfiles that the given trackfile is merged with.
+func (s *scope) mergesForContact(trackfile *trackfiles.Trackfile) []*trackfiles.Trackfile {
+	mergedWith := make([]*trackfiles.Trackfile, 0)
+	for other := range s.contacts.values() {
+		if trackfile.Contact.Coalition == other.Contact.Coalition {
+			continue
+		}
+		distance := spatial.Distance(trackfile.LastKnown().Point, other.LastKnown().Point)
+		if distance < brevity.MergeExitDistance {
+			mergedWith = append(mergedWith, other)
+		}
+	}
+	return mergedWith
+}

--- a/pkg/simpleradio/data/client.go
+++ b/pkg/simpleradio/data/client.go
@@ -21,8 +21,8 @@ import (
 
 // DataClient is a client for the SRS data protocol.
 type DataClient interface {
-	// Name returns the name of the client as it appears in the SRS client list and in in-game transmissions.
-	Name() string
+	// Info returns the client information.
+	Info() types.ClientInfo
 	// Run starts the SRS data client. It should be called exactly once. The given channel will be closed when the client is ready.
 	Run(context.Context, *sync.WaitGroup, chan<- any) error
 	// Send sends a message to the SRS server.
@@ -80,9 +80,9 @@ func NewClient(guid types.GUID, config types.ClientConfiguration) (DataClient, e
 	return client, nil
 }
 
-// Name implements DataClient.Name.
-func (c *dataClient) Name() string {
-	return c.clientInfo.Name
+// Info implements [DataClient.Info].
+func (c *dataClient) Info() types.ClientInfo {
+	return c.clientInfo
 }
 
 // Run implements DataClient.Run.


### PR DESCRIPTION
Fixes #186 and  #252

- Controller tracks which hostiles are merged with which friendlies.
  - Merge status is tracked per-aircraft. For brevity purposes, a group is considered to be merged with every aircraft any single member of the group is merged with.
  - Merge is entered when hostile and friendly are closer than 3 miles.
  - Merge is exited when hostile and friendly are further than 7 miles.
  - Merge status is removed if aircraft fades or the trackfile ages out.
- Controller broadcasts a MERGED call if friendlies on SRS merge with a hostile.
  - Simple batching of merges that occur within 15 second windows. Not as fancy as the faded queuing behavior on the grounds that merge calls need to be broadcast quickly.
    - May result in excessive number of calls during a large and complex furball.
  - Merged call example: "Dagger 11, Dagger 12, merged. 4 contacts, Fulcrum merged with 2 other friendlies"
- Controller now considers the declaration of any hostile or group currently in the merge to be FURBALL rather than HOSTILE.
- Composer includes a merged-with fill-in in the Core Information Format for BOGEY DOPE, PICTURE, DECLARE, SNAPLOCK, and THREAT calls.
  - Groups with declaration FURBALL now always exclude track direction on the grounds that it is likely to change rapidly.
  - example: "Group 123/45, 6000, furball, merged with 1 friendly, 2 contacts, flogger"