### PR TITLE
Improve results of DECLARE/SNAPLOCK calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
 	github.com/zaf/resample v1.5.0
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/sys v0.23.0
 	gopkg.in/hraban/opus.v2 v2.0.0-20230925203106-0188a62cb302
 	gotest.tools/gotestsum v1.11.0
@@ -202,7 +203,6 @@ require (
 	go.uber.org/automaxprocs v1.5.3 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20240314144324-c7f7c6466f7f // indirect
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect

--- a/pkg/controller/declare.go
+++ b/pkg/controller/declare.go
@@ -71,8 +71,8 @@ func (c *controller) HandleDeclare(request *brevity.DeclareRequest) {
 	altitudeMargin := unit.Length(5000) * unit.Foot
 	minAltitude := request.Altitude - altitudeMargin
 	maxAltitude := request.Altitude + altitudeMargin
-	friendlyGroups := c.scope.FindNearbyGroupsWithBullseye(pointOfInterest, minAltitude, maxAltitude, radius, c.coalition, brevity.Aircraft)
-	hostileGroups := c.scope.FindNearbyGroupsWithBullseye(pointOfInterest, minAltitude, maxAltitude, radius, c.coalition.Opposite(), brevity.Aircraft)
+	friendlyGroups := c.scope.FindNearbyGroupsWithBullseye(pointOfInterest, minAltitude, maxAltitude, radius, c.coalition, brevity.Aircraft, []uint64{trackfile.Contact.ID})
+	hostileGroups := c.scope.FindNearbyGroupsWithBullseye(pointOfInterest, minAltitude, maxAltitude, radius, c.coalition.Opposite(), brevity.Aircraft, []uint64{trackfile.Contact.ID})
 	logger.Debug().Int("friendly", len(friendlyGroups)).Int("hostile", len(hostileGroups)).Msg("queried groups near declared location")
 
 	response := brevity.DeclareResponse{Callsign: foundCallsign}

--- a/pkg/controller/snaplock.go
+++ b/pkg/controller/snaplock.go
@@ -47,6 +47,7 @@ func (c *controller) HandleSnaplock(request *brevity.SnaplockRequest) {
 		radius,
 		c.coalition,
 		brevity.Aircraft,
+		[]uint64{trackfile.Contact.ID},
 	)
 	hostileGroups := c.scope.FindNearbyGroupsWithBRAA(
 		origin,
@@ -56,6 +57,7 @@ func (c *controller) HandleSnaplock(request *brevity.SnaplockRequest) {
 		radius,
 		c.coalition.Opposite(),
 		brevity.Aircraft,
+		[]uint64{trackfile.Contact.ID},
 	)
 
 	response := brevity.SnaplockResponse{Callsign: foundCallsign}

--- a/pkg/radar/picture.go
+++ b/pkg/radar/picture.go
@@ -30,6 +30,7 @@ func (s *scope) GetPicture(radius unit.Length, coalition coalitions.Coalition, f
 		radius,
 		coalition,
 		filter,
+		[]uint64{},
 	)
 
 	// Sort groups from highest to lowest threat

--- a/pkg/radar/radar.go
+++ b/pkg/radar/radar.go
@@ -48,8 +48,9 @@ type Radar interface {
 		category brevity.ContactCategory,
 	) (int, []brevity.Group)
 	// FindNearbyGroupsWithBRAA returns all groups within the given radius of the given point of interest, within the given
-	// altitude block, filtered by the given coalition and contact category. Each group has BRAA set relative to the
-	// given origin.
+	// altitude block, filtered by the given coalition and contact category. Any given unit IDs are excluded from the search.
+	// Each group has BRAA set relative to the given origin. The groups are ordered by increasing distance from the point
+	// of interest.
 	FindNearbyGroupsWithBRAA(
 		origin,
 		pointOfInterest orb.Point,
@@ -58,10 +59,12 @@ type Radar interface {
 		radius unit.Length,
 		coalition coalitions.Coalition,
 		category brevity.ContactCategory,
+		excludedIDs []uint64,
 	) []brevity.Group
 	// FindNearbyGroupsWithBullseye returns all groups within the given radius of the given point of interest, within the given
-	// altitude block, filtered by the given coalition and contact category. Each group has Bullseye set relative to the
-	// point provided in SetBullseye.
+	// altitude block, filtered by the given coalition and contact category. Any given unit IDs are excluded from the search.
+	// Each group has Bullseye set relative to the point provided in SetBullseye. The groups are ordered by increasing distance
+	// from the point of interest.
 	FindNearbyGroupsWithBullseye(
 		pointOfInterest orb.Point,
 		minAltitude,
@@ -69,6 +72,7 @@ type Radar interface {
 		radius unit.Length,
 		coalition coalitions.Coalition,
 		category brevity.ContactCategory,
+		excludedIDs []uint64,
 	) []brevity.Group
 	// FindNearestGroupWithBRAA returns the nearest group to the given origin (up to the given radius), within the
 	// given altitude block, filtered by the given coalition and contact category. The group has BRAA set relative to

--- a/pkg/radar/threat.go
+++ b/pkg/radar/threat.go
@@ -24,6 +24,7 @@ func (s *scope) Threats(coalition coalitions.Coalition) map[brevity.Group][]uint
 			radius,
 			coalition.Opposite(),
 			brevity.Aircraft,
+			[]uint64{},
 		)
 
 		// Populate threats map with hostile-friendly relations that meet threat criteria.


### PR DESCRIPTION
- DECLARE/SNAPLOCK now examines the hostile and friendly groups which are closest to the point of interest
- The unit which initiated the request is excluded from the search

Fixes #275 