### PR TITLE
Improve DECLARE/SNAPLOCK parsing

### DIFF
--- a/docs/PLAYER.md
+++ b/docs/PLAYER.md
@@ -87,6 +87,7 @@ Some types of requests require you to provide numeric arguments.
 * Do not use ICAO pronunciation; pronounce numbers normally. Say "Three", "Five", "Nine", not "Tree", "Fife", "Niner".
 * When providing bullseye coordinates, you may either say "bullseye" before the coordinates, or omit the word "bullseye". That is, both "Bullseye Zero Six Five, Ninety-Nine" and "Zero Six Five, Ninety-Nine" are acceptable.
 * When providing bullseye coordinates, speak at a steady and measured pace with a slight pause between each number. Not too fast, not too slow. Don't mush your numbers together.
+* If the bot has trouble understanding your bullseye coordinates, you may use the separators "at" or "altitude" between the range and altitude. That is "Bullseye Zero Six Five, Ninety-Nine, at Twelve Thousand"
 
 Tips:
 

--- a/pkg/controller/declare.go
+++ b/pkg/controller/declare.go
@@ -67,10 +67,16 @@ func (c *controller) HandleDeclare(request *brevity.DeclareRequest) {
 	}
 	pointOfInterest := spatial.PointAtBearingAndDistance(origin, bearing, distance)
 
-	radius := 7 * unit.NauticalMile // TODO reduce to 3 when magvar is available
-	altitudeMargin := unit.Length(5000) * unit.Foot
-	minAltitude := request.Altitude - altitudeMargin
-	maxAltitude := request.Altitude + altitudeMargin
+	radius := 7 * unit.NauticalMile
+
+	minAltitude := lowestAltitude
+	maxAltitude := highestAltitude
+	if request.Altitude != 0 {
+		altitudeMargin := unit.Length(5000) * unit.Foot
+		minAltitude = request.Altitude - altitudeMargin
+		maxAltitude = request.Altitude + altitudeMargin
+	}
+
 	friendlyGroups := c.scope.FindNearbyGroupsWithBullseye(pointOfInterest, minAltitude, maxAltitude, radius, c.coalition, brevity.Aircraft, []uint64{trackfile.Contact.ID})
 	hostileGroups := c.scope.FindNearbyGroupsWithBullseye(pointOfInterest, minAltitude, maxAltitude, radius, c.coalition.Opposite(), brevity.Aircraft, []uint64{trackfile.Contact.ID})
 	logger.Debug().Int("friendly", len(friendlyGroups)).Int("hostile", len(hostileGroups)).Msg("queried groups near declared location")

--- a/pkg/parser/declare.go
+++ b/pkg/parser/declare.go
@@ -80,10 +80,9 @@ func (p *parser) parseDeclare(callsign string, scanner *bufio.Scanner) (*brevity
 	}
 
 	altitude, ok := p.parseAltitude(scanner)
-	if !ok {
-		return nil, false
+	if ok {
+		log.Debug().Int("altitude", int(altitude.Feet())).Msg("parsed altitude")
 	}
-	log.Debug().Int("altitude", int(altitude.Feet())).Msg("parsed altitude")
 
 	track := p.parseTrack(scanner)
 	log.Debug().Str("track", string(track)).Msg("parsed track")

--- a/pkg/parser/declare_test.go
+++ b/pkg/parser/declare_test.go
@@ -14,6 +14,66 @@ func TestParserDeclare(t *testing.T) {
 	t.Parallel()
 	testCases := []parserTestCase{
 		{
+			text: "anyface, chevy one one, declare, 075 26 2000",
+			expected: &brevity.DeclareRequest{
+				Callsign: "chevy 1 1",
+				Bullseye: *brevity.NewBullseye(
+					bearings.NewMagneticBearing(75*unit.Degree),
+					26*unit.NauticalMile,
+				),
+				Altitude: 2000 * unit.Foot,
+				Track:    brevity.UnknownDirection,
+			},
+		},
+		{
+			text: "anyface, chevy one one, declare, 075 26",
+			expected: &brevity.DeclareRequest{
+				Callsign: "chevy 1 1",
+				Bullseye: *brevity.NewBullseye(
+					bearings.NewMagneticBearing(75*unit.Degree),
+					26*unit.NauticalMile,
+				),
+				Altitude: 0,
+				Track:    brevity.UnknownDirection,
+			},
+		},
+		{
+			text: "anyface, chevy one one, declare, 075 26 at 2000",
+			expected: &brevity.DeclareRequest{
+				Callsign: "chevy 1 1",
+				Bullseye: *brevity.NewBullseye(
+					bearings.NewMagneticBearing(75*unit.Degree),
+					26*unit.NauticalMile,
+				),
+				Altitude: 2000 * unit.Foot,
+				Track:    brevity.UnknownDirection,
+			},
+		},
+		{
+			text: "anyface, chevy one one, declare bullseye 075 for 26 at 2000",
+			expected: &brevity.DeclareRequest{
+				Callsign: "chevy 1 1",
+				Bullseye: *brevity.NewBullseye(
+					bearings.NewMagneticBearing(75*unit.Degree),
+					26*unit.NauticalMile,
+				),
+				Altitude: 2000 * unit.Foot,
+				Track:    brevity.UnknownDirection,
+			},
+		},
+		{
+			text: "anyface, chevy one one, declare, 075 26 altitude 2000",
+			expected: &brevity.DeclareRequest{
+				Callsign: "chevy 1 1",
+				Bullseye: *brevity.NewBullseye(
+					bearings.NewMagneticBearing(75*unit.Degree),
+					26*unit.NauticalMile,
+				),
+				Altitude: 2000 * unit.Foot,
+				Track:    brevity.UnknownDirection,
+			},
+		},
+		{
 			text: "anyface, tater 1-1, declare bullseye 0-5-4, 123, 3000",
 			expected: &brevity.DeclareRequest{
 				Callsign: "tater 1 1",
@@ -125,13 +185,16 @@ func TestParserDeclare(t *testing.T) {
 		assert.Equal(t, expected.Callsign, actual.Callsign)
 		if expected.IsBRAA {
 			assert.True(t, actual.IsBRAA)
+			require.NotNil(t, actual)
 			require.NotNil(t, actual.Bearing)
 			assert.InDelta(t, expected.Bearing.Degrees(), actual.Bearing.Degrees(), 0.5)
 			require.NotNil(t, actual.Range)
 			assert.InDelta(t, expected.Range.NauticalMiles(), actual.Range.NauticalMiles(), 0.5)
 		} else {
 			assert.False(t, actual.IsBRAA)
+			require.NotNil(t, actual)
 			require.NotNil(t, actual.Bullseye)
+			require.NotNil(t, actual.Bullseye.Bearing())
 			assert.InDelta(t, expected.Bullseye.Bearing().Degrees(), actual.Bullseye.Bearing().Degrees(), 0.5)
 			assert.InDelta(t, expected.Bullseye.Distance().NauticalMiles(), actual.Bullseye.Distance().NauticalMiles(), 1)
 		}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -299,3 +299,12 @@ func ParsePilotCallsign(tx string) (callsign string, isValid bool) {
 
 	return callsign, true
 }
+
+func skipWords(scanner *bufio.Scanner, words ...string) bool {
+	for _, word := range words {
+		if IsSimilar(scanner.Text(), word) {
+			return scanner.Scan()
+		}
+	}
+	return true
+}

--- a/pkg/parser/snaplock_test.go
+++ b/pkg/parser/snaplock_test.go
@@ -34,6 +34,17 @@ func TestParserSnaplock(t *testing.T) {
 				),
 			},
 		},
+		{
+			text: "Anyface Fox 1 2 snaplock 058 for 147 at 3000",
+			expected: &brevity.SnaplockRequest{
+				Callsign: "fox 1 2",
+				BRA: brevity.NewBRA(
+					bearings.NewMagneticBearing(58*unit.Degree),
+					147*unit.NauticalMile,
+					3000*unit.Foot,
+				),
+			},
+		},
 	}
 	runParserTestCases(t, New(TestCallsign, true), testCases, func(t *testing.T, test parserTestCase, request any) {
 		t.Helper()


### PR DESCRIPTION
Related to #297 

- Fix a bug where altitude was not an optional field in a DECLARE request
- Allow the use of the separator words "for" "at" and "altitude" in a bullseye call