### PR TITLE
Remove Civil Aviation Pronunciation

### DIFF
--- a/pkg/composer/format.go
+++ b/pkg/composer/format.go
@@ -9,20 +9,20 @@ import (
 	"github.com/dharmab/skyeye/pkg/bearings"
 )
 
-// PronounceBearing composes a text representation ofbearing.
+// PronounceBearing composes a text representation of a bearing.
 func PronounceBearing(bearing bearings.Bearing) (s string) {
 	θ := int(bearing.RoundedDegrees())
 	s = PronounceInt(θ)
 	if θ < 10 {
-		s = "zero " + s
+		s = "0 " + s
 	}
 	if θ < 100 {
-		s = "zero " + s
+		s = "0 " + s
 	}
 	return
 }
 
-// PronounceInt composes a text representation of a a sequence of digits, using aviation pronunciation.
+// PronounceInt composes a text representation of a sequence of digits.
 func PronounceInt(d int) string {
 	if d < 0 {
 		return "minus " + PronounceInt(-d)
@@ -32,30 +32,7 @@ func PronounceInt(d int) string {
 		return PronounceInt(d/10) + " " + PronounceInt(d%10)
 	}
 
-	switch d {
-	case 0:
-		return "zero"
-	case 1:
-		return "one"
-	case 2:
-		return "two"
-	case 3:
-		return "three"
-	case 4:
-		return "four"
-	case 5:
-		return "five"
-	case 6:
-		return "six"
-	case 7:
-		return "seven"
-	case 8:
-		return "eight"
-	case 9:
-		return "nine"
-	}
-
-	panic(fmt.Sprintf("unexpected digit: %d", d))
+	return strconv.Itoa(d)
 }
 
 var defaultDecimalSeparator = "point"

--- a/pkg/composer/format.go
+++ b/pkg/composer/format.go
@@ -23,7 +23,6 @@ func PronounceBearing(bearing bearings.Bearing) (s string) {
 }
 
 // PronounceInt composes a text representation of a a sequence of digits, using aviation pronunciation.
-// 4 is pronounced "fower", 8 is pronounced "ait", and 9 is pronounced "niner".
 func PronounceInt(d int) string {
 	if d < 0 {
 		return "minus " + PronounceInt(-d)
@@ -41,19 +40,19 @@ func PronounceInt(d int) string {
 	case 2:
 		return "two"
 	case 3:
-		return "tree"
+		return "three"
 	case 4:
-		return "fohwer"
+		return "four"
 	case 5:
-		return "fife"
+		return "five"
 	case 6:
 		return "six"
 	case 7:
 		return "seven"
 	case 8:
-		return "ait"
+		return "eight"
 	case 9:
-		return "niner"
+		return "nine"
 	}
 
 	panic(fmt.Sprintf("unexpected digit: %d", d))

--- a/pkg/composer/format_test.go
+++ b/pkg/composer/format_test.go
@@ -14,31 +14,31 @@ func TestPronounceInt(t *testing.T) {
 		arg    int
 		expect string
 	}{
-		{arg: -1, expect: "minus one"},
-		{arg: 0, expect: "zero"},
-		{arg: 1, expect: "one"},
-		{arg: 2, expect: "two"},
-		{arg: 3, expect: "tree"},
-		{arg: 4, expect: "fohwer"},
-		{arg: 5, expect: "fife"},
-		{arg: 6, expect: "six"},
-		{arg: 7, expect: "seven"},
-		{arg: 8, expect: "ait"},
-		{arg: 9, expect: "niner"},
-		{arg: 10, expect: "one zero"},
-		{arg: 11, expect: "one one"},
-		{arg: 12, expect: "one two"},
-		{arg: 13, expect: "one tree"},
-		{arg: 14, expect: "one fohwer"},
-		{arg: 15, expect: "one fife"},
-		{arg: 16, expect: "one six"},
-		{arg: 17, expect: "one seven"},
-		{arg: 18, expect: "one ait"},
-		{arg: 19, expect: "one niner"},
-		{arg: 20, expect: "two zero"},
-		{arg: 308, expect: "tree zero ait"},
-		{arg: 1688, expect: "one six ait ait"},
-		{arg: 2992, expect: "two niner niner two"},
+		{arg: -1, expect: "minus 1"},
+		{arg: 0, expect: "0"},
+		{arg: 1, expect: "1"},
+		{arg: 2, expect: "2"},
+		{arg: 3, expect: "3"},
+		{arg: 4, expect: "4"},
+		{arg: 5, expect: "5"},
+		{arg: 6, expect: "6"},
+		{arg: 7, expect: "7"},
+		{arg: 8, expect: "8"},
+		{arg: 9, expect: "9"},
+		{arg: 10, expect: "1 0"},
+		{arg: 11, expect: "1 1"},
+		{arg: 12, expect: "1 2"},
+		{arg: 13, expect: "1 3"},
+		{arg: 14, expect: "1 4"},
+		{arg: 15, expect: "1 5"},
+		{arg: 16, expect: "1 6"},
+		{arg: 17, expect: "1 7"},
+		{arg: 18, expect: "1 8"},
+		{arg: 19, expect: "1 9"},
+		{arg: 20, expect: "2 0"},
+		{arg: 308, expect: "3 0 8"},
+		{arg: 1688, expect: "1 6 8 8"},
+		{arg: 2992, expect: "2 9 9 2"},
 	}
 	for _, test := range testCases {
 		t.Run(strconv.Itoa(test.arg), func(t *testing.T) {
@@ -57,11 +57,11 @@ func TestPronounceDecimal(t *testing.T) {
 		separator string
 		expect    string
 	}{
-		{arg: 136.0, precision: 0, separator: "", expect: "one tree six"},
-		{arg: 136.0, precision: 1, separator: "", expect: "one tree six point zero"},
-		{arg: 136.0, precision: 1, separator: "decimal", expect: "one tree six decimal zero"},
-		{arg: 249.500, precision: 1, separator: "", expect: "two fohwer niner point fife"},
-		{arg: 249.500, precision: 2, separator: "", expect: "two fohwer niner point fife zero"},
+		{arg: 136.0, precision: 0, separator: "", expect: "1 3 6"},
+		{arg: 136.0, precision: 1, separator: "", expect: "1 3 6 point 0"},
+		{arg: 136.0, precision: 1, separator: "decimal", expect: "1 3 6 decimal 0"},
+		{arg: 249.500, precision: 1, separator: "", expect: "2 4 9 point 5"},
+		{arg: 249.500, precision: 2, separator: "", expect: "2 4 9 point 5 0"},
 	}
 	for _, test := range testCases {
 		t.Run(fmt.Sprintf("%v %v %v", test.arg, test.precision, test.separator), func(t *testing.T) {


### PR DESCRIPTION
AIC/ABMs don't use the civil aviation pronunciations of e.g. "tree"/"fower"/"ait", etc.

Further, it (at least in my opinion) makes it harder to understand particularly with the AI, it doesn't do a great job of saying "fower" for example.