### PR TITLE
Allow Picture without a Pilot Callsign

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -220,11 +220,6 @@ func (p *parser) Parse(tx string) any {
 
 	// Handle cases where we heard our own callsign, but couldn't understand
 	// the request.
-	if !foundPilotCallsign && foundRequestWord {
-	    if requestWord == picture {
-	        return &brevity.PictureRequest{Callsign: nullCallsign}
-	    }
-    }
 	if !foundPilotCallsign {
 		logger.Trace().Msg("no pilot callsign found")
 		return &brevity.UnableToUnderstandRequest{}
@@ -232,6 +227,11 @@ func (p *parser) Parse(tx string) any {
 	if !foundRequestWord {
 		logger.Trace().Msg("no request word found")
 		return &brevity.UnableToUnderstandRequest{Callsign: pilotCallsign}
+	}
+	if !foundPilotCallsign && foundRequestWord {
+		if requestWord == picture {
+			return &brevity.PictureRequest{Callsign: nullCallsign}
+		}
 	}
 
 	// Try to parse a request from the remaining text.

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -228,10 +228,8 @@ func (p *parser) Parse(tx string) any {
 		logger.Trace().Msg("no request word found")
 		return &brevity.UnableToUnderstandRequest{Callsign: pilotCallsign}
 	}
-	if !foundPilotCallsign && foundRequestWord {
-		if requestWord == picture {
-			return &brevity.PictureRequest{Callsign: nullCallsign}
-		}
+	if !foundPilotCallsign && foundRequestWord && requestWord == picture {
+		return &brevity.PictureRequest{Callsign: nullCallsign}
 	}
 
 	// Try to parse a request from the remaining text.

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -45,6 +45,8 @@ const (
 	tripwire   string = "tripwire"
 )
 
+const nullCallsign string = "NULL"
+
 var requestWords = []string{radioCheck, alphaCheck, bogeyDope, declare, picture, spiked, snaplock, tripwire}
 
 var alternateRequestWords = map[string]string{
@@ -218,6 +220,11 @@ func (p *parser) Parse(tx string) any {
 
 	// Handle cases where we heard our own callsign, but couldn't understand
 	// the request.
+	if !foundPilotCallsign && foundRequestWord {
+	    if requestWord == picture {
+	        return &brevity.PictureRequest{Callsign: nullCallsign}
+	    }
+    }
 	if !foundPilotCallsign {
 		logger.Trace().Msg("no pilot callsign found")
 		return &brevity.UnableToUnderstandRequest{}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -45,8 +45,6 @@ const (
 	tripwire   string = "tripwire"
 )
 
-const nullCallsign string = "NULL"
-
 var requestWords = []string{radioCheck, alphaCheck, bogeyDope, declare, picture, spiked, snaplock, tripwire}
 
 var alternateRequestWords = map[string]string{
@@ -220,6 +218,9 @@ func (p *parser) Parse(tx string) any {
 
 	// Handle cases where we heard our own callsign, but couldn't understand
 	// the request.
+	if !foundPilotCallsign && foundRequestWord && requestWord == picture {
+		return &brevity.PictureRequest{Callsign: ""}
+	}
 	if !foundPilotCallsign {
 		logger.Trace().Msg("no pilot callsign found")
 		return &brevity.UnableToUnderstandRequest{}
@@ -227,9 +228,6 @@ func (p *parser) Parse(tx string) any {
 	if !foundRequestWord {
 		logger.Trace().Msg("no request word found")
 		return &brevity.UnableToUnderstandRequest{Callsign: pilotCallsign}
-	}
-	if !foundPilotCallsign && foundRequestWord && requestWord == picture {
-		return &brevity.PictureRequest{Callsign: nullCallsign}
 	}
 
 	// Try to parse a request from the remaining text.

--- a/pkg/parser/picture_test.go
+++ b/pkg/parser/picture_test.go
@@ -25,7 +25,7 @@ func TestParserPicture(t *testing.T) {
 		{
 			text: "anyface, picture",
 			expected: &brevity.PictureRequest{
-				Callsign: "NULL",
+				Callsign: "",
 			},
 		},
 	}

--- a/pkg/parser/picture_test.go
+++ b/pkg/parser/picture_test.go
@@ -22,12 +22,12 @@ func TestParserPicture(t *testing.T) {
 				Callsign: "intruder 1 1",
 			},
 		},
-        {
-            text: "anyface, picture",
-            expected: &brevity.PictureRequest{
-                Callsign: "NULL",
-            },
-        },
+		{
+			text: "anyface, picture",
+			expected: &brevity.PictureRequest{
+				Callsign: "NULL",
+			},
+		},
 	}
 	runParserTestCases(t, New(TestCallsign, true), testCases, func(t *testing.T, test parserTestCase, request any) {
 		t.Helper()

--- a/pkg/parser/picture_test.go
+++ b/pkg/parser/picture_test.go
@@ -22,6 +22,12 @@ func TestParserPicture(t *testing.T) {
 				Callsign: "intruder 1 1",
 			},
 		},
+        {
+            text: "anyface, picture",
+            expected: &brevity.PictureRequest{
+                Callsign: "NULL",
+            },
+        },
 	}
 	runParserTestCases(t, New(TestCallsign, true), testCases, func(t *testing.T, test parserTestCase, request any) {
 		t.Helper()


### PR DESCRIPTION
It should be valid to accept a picture request that does not have an attached pilot callsign, for example:

"SKYEYE, PICTURE."