### PR TITLE
Handle partial transforms and re-used object IDs in ACMI data

### DIFF
--- a/internal/cli/zerolog.go
+++ b/internal/cli/zerolog.go
@@ -9,10 +9,9 @@ import (
 )
 
 func SetupZerolog(levelName, formatName string) {
-	if strings.EqualFold(formatName, "json") {
+	if strings.EqualFold(formatName, "pretty") {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	}
-
 	var level zerolog.Level
 	switch strings.ToLower(levelName) {
 	case "error":

--- a/pkg/tacview/types/coordinate.go
+++ b/pkg/tacview/types/coordinate.go
@@ -1,0 +1,215 @@
+package types
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/martinlindhe/unit"
+	"github.com/paulmach/orb"
+	"github.com/rs/zerolog/log"
+)
+
+type Coordinates struct {
+	// Flag indicating the presence or absence of the related field
+	ValidLon, ValidLat bool
+	// Location is the object's lon/lat position
+	Location orb.Point
+	// Altitude above sea level
+	Altitude *unit.Length
+	// X is the object's native coordinate within the sim
+	X *float64
+	// Y is the object's native coordiante within the sim
+	Y *float64
+	// Roll angle
+	Roll *unit.Angle
+	// Pitch angle
+	Pitch *unit.Angle
+	// Yaw angle (this may be different from heading)
+	Yaw *unit.Angle
+	// Heading is the object's flat earth heading
+	Heading *unit.Angle
+}
+
+func NewCoordinates(
+	point orb.Point,
+	validLon, validLat bool,
+	altitude *unit.Length,
+	x, y *float64,
+	roll, pitch, yaw, heading *unit.Angle,
+) *Coordinates {
+	return &Coordinates{
+		Location: point,
+		ValidLon: validLon,
+		ValidLat: validLat,
+		Altitude: altitude,
+		X:        x,
+		Y:        y,
+		Roll:     roll,
+		Pitch:    pitch,
+		Yaw:      yaw,
+		Heading:  heading,
+	}
+}
+
+func (c *Coordinates) Update(next *Coordinates) {
+	longitude := c.Location.Lon()
+	if next.ValidLon {
+		longitude = next.Location.Lon()
+		c.ValidLon = true
+	}
+	latitude := c.Location.Lat()
+	if next.ValidLat {
+		latitude = next.Location.Lat()
+		c.ValidLat = true
+	}
+	c.Location = orb.Point{longitude, latitude}
+
+	if next.Altitude != nil {
+		c.Altitude = next.Altitude
+	}
+	if next.X != nil {
+		c.X = next.X
+	}
+	if next.Y != nil {
+		c.Y = next.Y
+	}
+	if next.Roll != nil {
+		c.Roll = next.Roll
+	}
+	if next.Pitch != nil {
+		c.Pitch = next.Pitch
+	}
+	if next.Yaw != nil {
+		c.Yaw = next.Yaw
+	}
+	if next.Heading != nil {
+		c.Heading = next.Heading
+	}
+}
+
+func (c *Coordinates) Parse(transform string, ref orb.Point) error {
+	fields := strings.Split(transform, "|")
+
+	logger := log.With().Str("transform", transform).Logger()
+	if len(fields) < 3 {
+		logger.Trace().Msg("unexpected number of fields in coordinate transformation")
+		return nil
+	}
+
+	var longitude, latitude float64
+	if fields[0] != "" {
+		offset, err := strconv.ParseFloat(fields[0], 64)
+		if err != nil {
+			logger.Trace().Err(err).Msg("error parsing longitude")
+		}
+		longitude = ref.Lon() + offset
+		c.ValidLon = true
+	}
+	if fields[1] != "" {
+		offset, err := strconv.ParseFloat(fields[1], 64)
+		if err != nil {
+			logger.Trace().Err(err).Msg("error parsing latitude")
+		}
+		latitude = ref.Lat() + offset
+		c.ValidLat = true
+	}
+	c.Location = orb.Point{longitude, latitude}
+
+	var alt, x, y, roll, pitch, yaw, heading string
+	switch len(fields) {
+	case 3:
+		alt = fields[2]
+	case 5:
+		alt = fields[2]
+		x = fields[3]
+		y = fields[4]
+	case 6:
+		alt = fields[2]
+		roll = fields[3]
+		pitch = fields[4]
+		yaw = fields[5]
+	case 9:
+		alt = fields[2]
+		roll = fields[3]
+		pitch = fields[4]
+		yaw = fields[5]
+		x = fields[6]
+		y = fields[7]
+		heading = fields[8]
+	default:
+		log.Error().Str("transform", transform).Msg("unexpected number of fields in coordinate transformation")
+		return fmt.Errorf("unexpected number of fields in coordinate transformation: %d", len(fields))
+	}
+
+	for s, fn := range map[string]func(float64){
+		alt: func(v float64) {
+			a := unit.Length(v) * unit.Meter
+			c.Altitude = &a
+		},
+		x: func(v float64) {
+			c.X = &v
+		},
+		y: func(v float64) {
+			c.Y = &v
+		},
+		roll: func(v float64) {
+			θ := unit.Angle(v) * unit.Degree
+			c.Roll = &θ
+		},
+		pitch: func(v float64) {
+			θ := unit.Angle(v) * unit.Degree
+			c.Pitch = &θ
+		},
+		yaw: func(v float64) {
+			θ := unit.Angle(v) * unit.Degree
+			c.Yaw = &θ
+		},
+		heading: func(v float64) {
+			θ := unit.Angle(v) * unit.Degree
+			c.Heading = &θ
+		},
+	} {
+		if s != "" {
+			n, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				return fmt.Errorf("error parsing native transform value: %w", err)
+			}
+			fn(n)
+		}
+	}
+
+	return nil
+}
+
+func (c *Coordinates) Transform(ref orb.Point) string {
+	fields := make([]string, 9)
+	if c.ValidLon {
+		fields[0] = fmt.Sprintf("%f", c.Location.Lon()-ref.Lon())
+	}
+	if c.ValidLat {
+		fields[1] = fmt.Sprintf("%f", c.Location.Lat()-ref.Lat())
+	}
+	if c.Altitude != nil {
+		fields[2] = fmt.Sprintf("%f", c.Altitude.Meters())
+	}
+	if c.Roll != nil {
+		fields[3] = fmt.Sprintf("%f", c.Roll.Degrees())
+	}
+	if c.Pitch != nil {
+		fields[4] = fmt.Sprintf("%f", c.Pitch.Degrees())
+	}
+	if c.Yaw != nil {
+		fields[5] = fmt.Sprintf("%f", c.Yaw.Degrees())
+	}
+	if c.X != nil {
+		fields[6] = fmt.Sprintf("%f", *c.X)
+	}
+	if c.Y != nil {
+		fields[7] = fmt.Sprintf("%f", *c.Y)
+	}
+	if c.Heading != nil {
+		fields[8] = fmt.Sprintf("%f", c.Heading.Degrees())
+	}
+	return strings.Join(fields, "|")
+}

--- a/pkg/tacview/types/metadata_test.go
+++ b/pkg/tacview/types/metadata_test.go
@@ -1,0 +1,168 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dharmab/skyeye/pkg/tacview/properties"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTimeFrame(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		line             string
+		expectedDuration time.Duration
+		expectedError    bool
+	}{
+		{
+			line:             "#0.0000000",
+			expectedDuration: 0,
+		},
+		{
+			line:             "#122.510000",
+			expectedDuration: 122*time.Second + 510*time.Millisecond,
+		},
+		{
+			line:          "1b02,T=||-30.94",
+			expectedError: true,
+		},
+		{
+			line:          "-1c02",
+			expectedError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.line, func(t *testing.T) {
+			t.Parallel()
+			actual, err := ParseTimeFrame(testCase.line)
+			if testCase.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, testCase.expectedDuration, actual)
+			}
+		})
+	}
+}
+
+func TestParseObjectUpdate(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		line           string
+		expectedUpdate *ObjectUpdate
+		expectedError  *error
+	}{
+		{
+			line: "40000001,T=5.9005604|5.0219182|2000,Type=Navaid+Static+Bullseye,Color=Blue,Coalition=Enemies",
+			expectedUpdate: &ObjectUpdate{
+				ID: 0x40000001,
+				Properties: map[string]string{
+					properties.Transform: "5.9005604|5.0219182|2000",
+					properties.Type:      "Navaid+Static+Bullseye",
+					properties.Color:     "Blue",
+					properties.Coalition: "Enemies",
+				},
+			},
+		},
+		{
+			line: "40000002,T=5.9005604|5.0219182|2000,Type=Navaid+Static+Bullseye,Color=Grey,Coalition=Neutrals",
+			expectedUpdate: &ObjectUpdate{
+				ID: 0x40000002,
+				Properties: map[string]string{
+					properties.Transform: "5.9005604|5.0219182|2000",
+					properties.Type:      "Navaid+Static+Bullseye",
+					properties.Color:     "Grey",
+					properties.Coalition: "Neutrals",
+				},
+			},
+		},
+		{
+			line: "40000003,T=5.9004647|5.0217148|2000|-9.44|-22.3,Type=Navaid+Static+Bullseye,Color=Red,Coalition=Allies",
+			expectedUpdate: &ObjectUpdate{
+				ID: 0x40000003,
+				Properties: map[string]string{
+					properties.Transform: "5.9004647|5.0217148|2000|-9.44|-22.3",
+					properties.Type:      "Navaid+Static+Bullseye",
+					properties.Color:     "Red",
+					properties.Coalition: "Allies",
+				},
+			},
+		},
+		{
+			line: "14a02,T=5.5317022|3.2532355|598.99|||264.5|-40343.46|-195137.77|266.4,Type=Ground+Light+Human+Infantry,Name=Soldier M4,Pilot=Hound 1-1,Group=Hound 1,Color=Blue,Coalition=Enemies,Country=xb",
+			expectedUpdate: &ObjectUpdate{
+				ID: 0x14a02,
+				Properties: map[string]string{
+					properties.Transform: "5.5317022|3.2532355|598.99|||264.5|-40343.46|-195137.77|266.4",
+					properties.Type:      "Ground+Light+Human+Infantry",
+					properties.Name:      "Soldier M4",
+					properties.Pilot:     "Hound 1-1",
+					properties.Group:     "Hound 1",
+					properties.Color:     "Blue",
+					properties.Coalition: "Enemies",
+					properties.Country:   "xb",
+				},
+			},
+		},
+		{
+			line: "-14a02",
+			expectedUpdate: &ObjectUpdate{
+				ID:         0x14a02,
+				IsRemoval:  true,
+				Properties: map[string]string{},
+			},
+		},
+		{
+			line: "7a302,T=5.4407523|5.6618178|||3.6|84.5|-39416.41|72413.32|86.6",
+			expectedUpdate: &ObjectUpdate{
+				ID: 0x7a302,
+				Properties: map[string]string{
+					properties.Transform: "5.4407523|5.6618178|||3.6|84.5|-39416.41|72413.32|86.6",
+				},
+			},
+		},
+		{
+			line: "1b02,T=||-30.94",
+			expectedUpdate: &ObjectUpdate{
+				ID: 0x1b02,
+				Properties: map[string]string{
+					properties.Transform: "||-30.94",
+				},
+			},
+		},
+		{
+			line: "1c02,T=||-60.6",
+			expectedUpdate: &ObjectUpdate{
+				ID: 0x1c02,
+				Properties: map[string]string{
+					properties.Transform: "||-60.6",
+				},
+			},
+		},
+		{
+			line: "a03,T=|||-34817.79|",
+			expectedUpdate: &ObjectUpdate{
+				ID: 0xa03,
+				Properties: map[string]string{
+					properties.Transform: "|||-34817.79|",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.line, func(t *testing.T) {
+			t.Parallel()
+			actual, err := ParseObjectUpdate(testCase.line)
+			if testCase.expectedError != nil {
+				require.NoError(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, testCase.expectedUpdate, actual)
+			}
+		})
+	}
+}

--- a/pkg/tacview/types/object.go
+++ b/pkg/tacview/types/object.go
@@ -10,13 +10,12 @@ import (
 	"github.com/dharmab/skyeye/pkg/tacview/properties"
 	"github.com/martinlindhe/unit"
 	"github.com/paulmach/orb"
-	"github.com/rs/zerolog/log"
 )
 
 type Object struct {
 	ID         uint64
 	properties map[string]string
-	mut        sync.Mutex
+	mut        sync.RWMutex
 }
 
 func NewObject(id uint64) *Object {
@@ -26,18 +25,28 @@ func NewObject(id uint64) *Object {
 	}
 }
 
-type Coordinates struct {
-	Location orb.Point
-	Altitude unit.Length
-	// X is the object's native coordinate within the sim
-	X float64
-	// Y is the object's native coordiante within the sim
-	Y     float64
-	Roll  unit.Angle
-	Pitch unit.Angle
-	Yaw   unit.Angle
-	// Heading is the object's flat earth heading
-	Heading unit.Angle
+func (o *Object) Update(update *ObjectUpdate, ref orb.Point) error {
+	var newTransform string
+	for k, v := range update.Properties {
+		if k == properties.Transform {
+			newTransform = v
+		} else {
+			o.SetProperty(k, v)
+		}
+	}
+
+	currentCoordinates, err := o.GetCoordinates(ref)
+	if err != nil {
+		o.SetProperty(properties.Transform, newTransform)
+		//lint:ignore nilerr intentional overwrite of invalid coordinates
+		return nil // ignore
+	}
+	err = currentCoordinates.Parse(newTransform, ref)
+	if err != nil {
+		return fmt.Errorf("error parsing coordinates: %w", err)
+	}
+	o.SetProperty(properties.Transform, currentCoordinates.Transform(ref))
+	return nil
 }
 
 func (o *Object) SetProperty(p, v string) {
@@ -47,8 +56,6 @@ func (o *Object) SetProperty(p, v string) {
 }
 
 func (o *Object) GetProperty(p string) (string, bool) {
-	o.mut.Lock()
-	defer o.mut.Unlock()
 	val, ok := o.properties[p]
 	if !ok {
 		return "", false
@@ -58,6 +65,8 @@ func (o *Object) GetProperty(p string) (string, bool) {
 
 // GetTypes returns all object type tags.
 func (o *Object) GetTypes() ([]string, error) {
+	o.mut.RLock()
+	defer o.mut.RUnlock()
 	val, ok := o.GetProperty(properties.Type)
 	if !ok {
 		return nil, errors.New("object does not contain types")
@@ -70,85 +79,15 @@ func (o *Object) GetTypes() ([]string, error) {
 // In such a case, the function returns nil and no error.
 // ref is the reference point from the global properties.
 func (o *Object) GetCoordinates(ref orb.Point) (*Coordinates, error) {
-	c := &Coordinates{}
-
 	val, ok := o.GetProperty(properties.Transform)
 	if !ok {
 		return nil, errors.New("object does not contain coordinate transformation")
 	}
-	fields := strings.Split(val, "|")
 
-	logger := log.With().Uint64("id", o.ID).Str("transform", val).Logger()
-	if len(fields) < 3 {
-		logger.Trace().Msg("unexpected number of fields in coordinate transformation")
-		return nil, nil
-	}
-	if fields[0] == "" || fields[1] == "" {
-		logger.Trace().Msg("missing longitude or latitude in coordinate transformation")
-		return nil, nil
-	}
-
-	longitude, err := strconv.ParseFloat(fields[0], 64)
+	c := &Coordinates{}
+	err := c.Parse(val, ref)
 	if err != nil {
-		logger.Trace().Err(err).Msg("error parsing longitude")
-		return c, nil
-	}
-	longitude = longitude + ref.Lon()
-
-	latitude, err := strconv.ParseFloat(fields[1], 64)
-	if err != nil {
-		logger.Trace().Err(err).Msg("error parsing latitude")
-		return c, nil
-	}
-	latitude = latitude + ref.Lat()
-
-	c.Location = orb.Point{longitude, latitude}
-
-	if fields[2] != "" {
-		if altitude, err := strconv.ParseFloat(fields[2], 64); err != nil {
-			logger.Trace().Err(err).Msg("error parsing altitude")
-		} else {
-			c.Altitude = unit.Length(altitude) * unit.Meter
-		}
-	}
-
-	var x, y, roll, pitch, yaw, heading string
-	switch len(fields) {
-	case 3:
-		// already parsed above
-	case 5:
-		x = fields[3]
-		y = fields[4]
-	case 6:
-		roll = fields[3]
-		pitch = fields[4]
-		yaw = fields[5]
-	case 9:
-		roll = fields[3]
-		pitch = fields[4]
-		yaw = fields[5]
-		x = fields[6]
-		y = fields[7]
-		heading = fields[8]
-	default:
-		log.Error().Str("transform", val).Msg("unexpected number of fields in coordinate transformation")
-		return c, fmt.Errorf("unexpected number of fields in coordinate transformation: %d", len(fields))
-	}
-	for s, fn := range map[string]func(float64){
-		x:       func(v float64) { c.X = v },
-		y:       func(v float64) { c.Y = v },
-		roll:    func(v float64) { c.Roll = unit.Angle(v) * unit.Degree },
-		pitch:   func(v float64) { c.Pitch = unit.Angle(v) * unit.Degree },
-		yaw:     func(v float64) { c.Yaw = unit.Angle(v) * unit.Degree },
-		heading: func(v float64) { c.Heading = unit.Angle(v) * unit.Degree },
-	} {
-		if s != "" {
-			n, err := strconv.ParseFloat(s, 64)
-			if err != nil {
-				return c, fmt.Errorf("error parsing native x: %w", err)
-			}
-			fn(n)
-		}
+		return nil, fmt.Errorf("error parsing coordinates: %w", err)
 	}
 	return c, nil
 }

--- a/pkg/tacview/types/object_test.go
+++ b/pkg/tacview/types/object_test.go
@@ -1,0 +1,109 @@
+package types
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/martinlindhe/unit"
+	"github.com/paulmach/orb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// p converts a value to a pointer.
+func p[T any](v T) *T { return &v }
+
+func TestObjectGetCoordinates(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		reference orb.Point
+		id        uint64
+		lines     []string
+		want      *Coordinates
+		wantErr   bool
+	}{
+		{
+			reference: orb.Point{30, 30},
+			id:        0xa03,
+			lines: []string{
+				"a03,T=5.4309806|6.9989461|60.47||0.1|322.8|-34817.79|220847.14|325,Type=Air+FixedWing,Name=F-4E-45MC,Pilot=Phantom 1-1 | User,Group=Incirlik | 163rd TFG 1-1,Color=Blue,Coalition=Enemies,Country=xb",
+			},
+			want: NewCoordinates(
+				orb.Point{35.4309806, 36.9989461},
+				true, true,
+				p(60.47*unit.Meter),
+				p(-34817.79), p(220847.14),
+				nil, p(0.1*unit.Degree), p(322.8*unit.Degree),
+				p(325*unit.Degree),
+			),
+			wantErr: false,
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			o := NewObject(testCase.id)
+			for _, line := range testCase.lines {
+				update, err := ParseObjectUpdate(line)
+				require.NoError(t, err)
+				for k, v := range update.Properties {
+					o.SetProperty(k, v)
+				}
+			}
+
+			c, err := o.GetCoordinates(testCase.reference)
+			if testCase.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, testCase.want.ValidLon, c.ValidLon)
+				if testCase.want.ValidLon {
+					assert.InDelta(t, testCase.want.Location.Lon(), c.Location.Lon(), 0.01)
+				}
+				assert.Equal(t, testCase.want.ValidLat, c.ValidLat)
+				if testCase.want.ValidLat {
+					assert.InDelta(t, testCase.want.Location.Lat(), c.Location.Lat(), 0.01)
+				}
+				if testCase.want.Altitude != nil {
+					assert.InDelta(t, testCase.want.Altitude.Meters(), c.Altitude.Meters(), 1)
+				} else {
+					assert.Nil(t, c.Altitude)
+				}
+				if testCase.want.Roll != nil {
+					assert.InDelta(t, testCase.want.Roll.Degrees(), c.Roll.Degrees(), 0.1)
+				} else {
+					assert.Nil(t, c.Roll)
+				}
+				if testCase.want.Pitch != nil {
+					assert.InDelta(t, testCase.want.Pitch.Degrees(), c.Pitch.Degrees(), 0.1)
+				} else {
+					assert.Nil(t, c.Pitch)
+				}
+				if testCase.want.Yaw != nil {
+					assert.InDelta(t, testCase.want.Yaw.Degrees(), c.Yaw.Degrees(), 0.1)
+				} else {
+					assert.Nil(t, c.Yaw)
+				}
+				if testCase.want.X != nil {
+					assert.NotNil(t, c.X)
+					assert.InDelta(t, *testCase.want.X, *c.X, 1)
+				} else {
+					assert.Nil(t, c.X)
+				}
+				if testCase.want.Y != nil {
+					assert.NotNil(t, c.Y)
+					assert.InDelta(t, *testCase.want.Y, *c.Y, 1)
+				} else {
+					assert.Nil(t, c.Y)
+				}
+				if testCase.want.Heading != nil {
+					assert.InDelta(t, testCase.want.Heading.Degrees(), c.Heading.Degrees(), 0.1)
+				} else {
+					assert.Nil(t, c.Heading)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Previously, we ignored any ACMI transform property which did not include longitude, latitude and altitude. Now, we properly handle transforms that only include one or two of these properties by merging them iwth any previous transform.
- Sometimes the ACMI data re-uses the same object ID for a different aircraft at a later point in time. Handle this case by explcitly removing the object if a property changes which should be static for the life of an aircraft, then publishing an explicitly new object. This should ensure that the downstream trackfile's labels are updated, even if trackfile didn't age out between the object lifecycles.