### PR TITLE
Only broadcast FADED calls when contact is near a friendly aircraft

### DIFF
--- a/docs/PLAYER.md
+++ b/docs/PLAYER.md
@@ -321,7 +321,7 @@ Your own aircraft must be on the SRS frequency, and using the same name in DCS a
 
 ### FADED
 
-When the GCI controller sees a contact disappear from the radar scope for at least 30 seconds, it will announce the contact is FADED.
+When the GCI controller sees a hostile contact within weapons range of a friendly aircraft disappear from the radar scope for at least 30 seconds, it will announce the hostile contact is FADED.
 
 **This is not a confirmation that the contact has been destroyed!** In DCS, it is possible for aircraft to be marked dead while they are still alive and dangerous.
 

--- a/pkg/controller/callbacks.go
+++ b/pkg/controller/callbacks.go
@@ -1,0 +1,47 @@
+package controller
+
+import (
+	"github.com/dharmab/skyeye/pkg/brevity"
+	"github.com/dharmab/skyeye/pkg/coalitions"
+	"github.com/dharmab/skyeye/pkg/traces"
+	"github.com/dharmab/skyeye/pkg/trackfiles"
+	"github.com/martinlindhe/unit"
+	"github.com/paulmach/orb"
+	"github.com/rs/zerolog/log"
+)
+
+var fadeBroadcastRadius = 55 * unit.NauticalMile
+
+func (c *controller) handleFaded(location orb.Point, group brevity.Group, coalition coalitions.Coalition) {
+	for _, id := range group.ObjectIDs() {
+		c.remove(id)
+	}
+	isHostile := coalition == c.coalition.Opposite()
+	areHumansOnFrequency := c.srsClient.HumansOnFrequency() > 0
+	nearbyFriendlies := c.scope.FindNearbyGroupsWithBullseye(
+		location,
+		lowestAltitude,
+		highestAltitude,
+		fadeBroadcastRadius,
+		c.coalition,
+		brevity.Aircraft,
+		[]uint64{},
+	)
+	isNearFriendly := len(nearbyFriendlies) > 0
+
+	if isHostile && isNearFriendly && areHumansOnFrequency {
+		log.Info().Stringer("group", group).Msg("broadcasting FADED call")
+		group.SetDeclaration(brevity.Hostile)
+		c.calls <- NewCall(traces.NewRequestContext(), brevity.FadedCall{Group: group})
+	} else {
+		log.Debug().
+			Bool("isHostile", isHostile).
+			Bool("isNearFriendly", isNearFriendly).
+			Bool("areHumansOnFrequency", areHumansOnFrequency).
+			Msg("skipping FADED call because broadcast criteria are not met")
+	}
+}
+
+func (c *controller) handleRemoved(trackfile trackfiles.Trackfile) {
+	c.remove(trackfile.Contact.ID)
+}

--- a/pkg/radar/callbacks.go
+++ b/pkg/radar/callbacks.go
@@ -4,11 +4,12 @@ import (
 	"github.com/dharmab/skyeye/pkg/brevity"
 	"github.com/dharmab/skyeye/pkg/coalitions"
 	"github.com/dharmab/skyeye/pkg/trackfiles"
+	"github.com/paulmach/orb"
 )
 
 // FadedCallback is a callback function that is called when a group has not been updated by sensors for a timeout period.
 // The group and its coalition are provided.
-type FadedCallback func(group brevity.Group, coalition coalitions.Coalition)
+type FadedCallback func(location orb.Point, group brevity.Group, coalition coalitions.Coalition)
 
 func (s *scope) SetFadedCallback(callback FadedCallback) {
 	s.fadedCallback = callback

--- a/pkg/radar/faded.go
+++ b/pkg/radar/faded.go
@@ -83,7 +83,7 @@ func (s *scope) handleFaded(fades []sim.Faded) {
 	// call the faded callback for each group
 	for _, grp := range groups {
 		if s.fadedCallback != nil {
-			s.fadedCallback(&grp, grp.contacts[0].Contact.Coalition)
+			s.fadedCallback(grp.point(), &grp, grp.contacts[0].Contact.Coalition)
 		}
 	}
 }


### PR DESCRIPTION
Suppress FADED calls for hostile aircraft which are greater than 55 miles away from any friendly. Rationale is that FADED is relevant for targeted aircraft and this is our current best proxy variable for a potentially targeted aircraft.