### PR TITLE
Correct various race conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,10 @@ $(SKYEYE_BIN): generate $(SKYEYE_SOURCES) $(LIBWHISPER_PATH) $(WHISPER_H_PATH)
 $(SKYEYE_SCALER_BIN): generate $(SKYEYE_SOURCES)
 	$(BUILD_VARS) $(GO) build $(BUILD_FLAGS) ./cmd/skyeye-scaler/
 
+.PHONY: run
+run:
+	$(BUILD_VARS) $(GO) run -race $(BUILD_FLAGS) ./cmd/skyeye/ $(ARGS)
+
 .PHONY: test
 test: generate
 	$(BUILD_VARS) $(GO) run gotest.tools/gotestsum -- $(BUILD_FLAGS) ./...

--- a/internal/application/app.go
+++ b/internal/application/app.go
@@ -190,7 +190,7 @@ func (a *app) Run(ctx context.Context, cancel context.CancelFunc, wg *sync.WaitG
 	go func() {
 		defer wg.Done()
 		log.Info().Msg("streaming telemetry data to radar")
-		a.tacviewClient.Stream(ctx, a.starts, a.updates, a.fades)
+		a.tacviewClient.Stream(ctx, wg, a.starts, a.updates, a.fades)
 	}()
 
 	wg.Add(1)

--- a/pkg/controller/callbacks.go
+++ b/pkg/controller/callbacks.go
@@ -48,6 +48,6 @@ func (c *controller) handleFaded(location orb.Point, group brevity.Group, coalit
 	}
 }
 
-func (c *controller) handleRemoved(trackfile trackfiles.Trackfile) {
+func (c *controller) handleRemoved(trackfile *trackfiles.Trackfile) {
 	c.remove(trackfile.Contact.ID)
 }

--- a/pkg/radar/callbacks.go
+++ b/pkg/radar/callbacks.go
@@ -10,6 +10,8 @@ import (
 type StartedCallback func()
 
 func (s *scope) SetStartedCallback(callback StartedCallback) {
+	s.callbackLock.Lock()
+	defer s.callbackLock.Unlock()
 	s.startedCallback = callback
 }
 
@@ -18,13 +20,17 @@ func (s *scope) SetStartedCallback(callback StartedCallback) {
 type FadedCallback func(location orb.Point, group brevity.Group, coalition coalitions.Coalition)
 
 func (s *scope) SetFadedCallback(callback FadedCallback) {
+	s.callbackLock.Lock()
+	defer s.callbackLock.Unlock()
 	s.fadedCallback = callback
 }
 
 // RemovedCallback is a callback function that is called when a trackfile is aged out and removed.
 // A copy of the trackfile is provided.
-type RemovedCallback func(trackfile trackfiles.Trackfile)
+type RemovedCallback func(trackfile *trackfiles.Trackfile)
 
 func (s *scope) SetRemovedCallback(callback RemovedCallback) {
+	s.callbackLock.Lock()
+	defer s.callbackLock.Unlock()
 	s.removalCallback = callback
 }

--- a/pkg/radar/faded.go
+++ b/pkg/radar/faded.go
@@ -89,6 +89,8 @@ func (s *scope) handleFaded(fades []sim.Faded) {
 	}
 
 	// call the faded callback for each group
+	s.callbackLock.RLock()
+	defer s.callbackLock.RUnlock()
 	for _, grp := range groups {
 		if s.fadedCallback != nil {
 			s.fadedCallback(grp.point(), &grp, grp.contacts[0].Contact.Coalition)

--- a/pkg/radar/radar.go
+++ b/pkg/radar/radar.go
@@ -133,6 +133,7 @@ type scope struct {
 	startedCallback       StartedCallback
 	fadedCallback         FadedCallback
 	removalCallback       RemovedCallback
+	callbackLock          sync.RWMutex
 	center                orb.Point
 	mandatoryThreatRadius unit.Length
 }
@@ -239,7 +240,7 @@ func (s *scope) handleGarbageCollection() {
 				Stringer("age", s.missionTime.Sub(lastSeen)).
 				Msg("expired trackfile")
 			if s.removalCallback != nil {
-				s.removalCallback(*trackfile)
+				s.removalCallback(trackfile)
 			}
 		}
 	}

--- a/pkg/radar/started.go
+++ b/pkg/radar/started.go
@@ -5,6 +5,8 @@ import "github.com/rs/zerolog/log"
 func (s *scope) handleStarted() {
 	log.Info().Msg("clearing all trackfiles due to mission (re)start")
 	s.contacts.reset()
+	s.callbackLock.RLock()
+	defer s.callbackLock.RUnlock()
 	if s.startedCallback != nil {
 		s.startedCallback()
 	}

--- a/pkg/sim/sim.go
+++ b/pkg/sim/sim.go
@@ -1,28 +1,8 @@
-// package sim provides an inteface for receiving telemetry data from DCS World
 package sim
 
 import (
-	"context"
-	"time"
-
-	"github.com/dharmab/skyeye/pkg/coalitions"
 	"github.com/dharmab/skyeye/pkg/trackfiles"
-	"github.com/paulmach/orb"
 )
-
-// Sim is the interface for receiving telemetry data from the flight simulator.
-type Sim interface {
-	// Stream aircraft updates from the sim to the provided channels.
-	// The first channel receives updates for active aircraft.
-	// The second channel receives messages when an aircraft disappears.
-	// This function blocks until the context is cancelled.
-	Stream(context.Context, chan<- Started, chan<- Updated, chan<- Faded)
-	// Bullseye returns the coalition's bullseye center.
-	Bullseye(coalitions.Coalition) (orb.Point, error)
-	// Time returns the starting time of the mission.
-	// This is useful for looking up magnetic variation.
-	Time() time.Time
-}
 
 // Started is a message sent when a new mission starts.
 type Started struct {

--- a/pkg/simpleradio/ping.go
+++ b/pkg/simpleradio/ping.go
@@ -58,7 +58,12 @@ func (c *client) receivePings(ctx context.Context, in <-chan []byte) {
 				log.Debug().Int("bytes", n).Msg("received UDP ping larger than expected")
 			} else {
 				log.Trace().Str("GUID", string(b[0:types.GUIDLength])).Msg("received UDP ping")
-				c.lastPing = time.Now()
+				t := time.Now()
+				func() {
+					c.lastPingLock.Lock()
+					defer c.lastPingLock.Unlock()
+					c.lastPing = t
+				}()
 			}
 		case <-ctx.Done():
 			log.Info().Msg("stopping SRS ping receiver due to context cancellation")

--- a/pkg/tacview/client/interface.go
+++ b/pkg/tacview/client/interface.go
@@ -3,11 +3,16 @@ package client
 import (
 	"context"
 	"sync"
+	"time"
 
+	"github.com/dharmab/skyeye/pkg/coalitions"
 	"github.com/dharmab/skyeye/pkg/sim"
+	"github.com/paulmach/orb"
 )
 
 type Client interface {
-	sim.Sim
 	Run(context.Context, *sync.WaitGroup) error
+	Stream(context.Context, *sync.WaitGroup, chan<- sim.Started, chan<- sim.Updated, chan<- sim.Faded)
+	Bullseye(coalitions.Coalition) (orb.Point, error)
+	Time() time.Time
 }


### PR DESCRIPTION
- Added a `run` target to run SkyEye with data race detection
- Trackfile deques are now protected by a mutex
- Radar scope callbacks are now protected by a mutex
- SRS last ping time is now protected by a mutex
- Tacview client significantly modified
  - Removed the `sim.Sim` interface in favor of `tacview.Client`
  - Client now has dedicated goroutines for mission start events and aircraft removal events, resolving a race condition that could deadlock reading updates from tacview.