### PR TITLE
Simplify merged call

### DIFF
--- a/pkg/brevity/merged.go
+++ b/pkg/brevity/merged.go
@@ -7,8 +7,6 @@ import (
 type MergedCall struct {
 	// Callsigns of the friendly aircraft in the merge.
 	Callsigns []string
-	// Hostile contacts that are merging with the friendly aircraft.
-	Group Group
 }
 
 const (

--- a/pkg/composer/group.go
+++ b/pkg/composer/group.go
@@ -127,30 +127,6 @@ func (c *composer) ComposeGroup(group brevity.Group) NaturalLanguageResponse {
 	}
 }
 
-// ComposeMergedWithGroup is a short form of describing a group for use in merge calls.
-func (c *composer) ComposeMergedWithGroup(group brevity.Group) NaturalLanguageResponse {
-	var speech, subtitle strings.Builder
-	if group.Contacts() > 1 {
-		contacts := c.ComposeContacts(group.Contacts())
-		speech.WriteString(contacts.Speech)
-		subtitle.WriteString(contacts.Subtitle)
-	}
-
-	if group.MergedWith() > 0 {
-		mergedWith := " merged with 1 other friendly"
-		if group.MergedWith() > 1 {
-			mergedWith = fmt.Sprintf(" merged with %d other friendlies", group.MergedWith())
-		}
-		speech.WriteString(mergedWith)
-		subtitle.WriteString(mergedWith)
-	}
-
-	return NaturalLanguageResponse{
-		Subtitle: subtitle.String(),
-		Speech:   speech.String(),
-	}
-}
-
 // ComposeContacts communicates the number of contacts in a group.
 // Reference: ATP 3-52.4 chapter IV section 2.
 func (c *composer) ComposeContacts(n int) NaturalLanguageResponse {

--- a/pkg/composer/merged.go
+++ b/pkg/composer/merged.go
@@ -1,19 +1,15 @@
 package composer
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/dharmab/skyeye/pkg/brevity"
 )
 
 func (c *composer) ComposeMergedCall(call brevity.MergedCall) NaturalLanguageResponse {
-	callsignList := strings.Join(call.Callsigns, ", ")
-	group := c.ComposeMergedWithGroup(call.Group)
-	template := "%s, merged, %s."
-
+	s := strings.Join(call.Callsigns, ", ") + ", merged."
 	return NaturalLanguageResponse{
-		Subtitle: fmt.Sprintf(template, callsignList, group.Subtitle),
-		Speech:   fmt.Sprintf(template, callsignList, group.Speech),
+		Subtitle: s,
+		Speech:   s,
 	}
 }

--- a/pkg/controller/merged.go
+++ b/pkg/controller/merged.go
@@ -121,7 +121,7 @@ func (c *controller) broadcastMerges(ctx context.Context) {
 		newMergedFriendlies := c.updateMergesForGroup(hostileGroup, friendlies)
 
 		logger := log.With().Stringer("group", hostileGroup).Logger()
-		mergedCall := c.createMergedCall(hostileGroup, newMergedFriendlies)
+		mergedCall := c.createMergedCall(newMergedFriendlies)
 		if len(mergedCall.Callsigns) > 0 {
 			logger.Info().Strs("callsigns", mergedCall.Callsigns).Msg("broadcasting merged call")
 			c.calls <- NewCall(ctx, mergedCall)
@@ -196,9 +196,8 @@ func (c *controller) updateMergesForContact(hostile, friendly *trackfiles.Trackf
 	return false
 }
 
-func (c *controller) createMergedCall(hostileGroup brevity.Group, friendlies []*trackfiles.Trackfile) brevity.MergedCall {
+func (c *controller) createMergedCall(friendlies []*trackfiles.Trackfile) brevity.MergedCall {
 	call := brevity.MergedCall{
-		Group:     hostileGroup,
 		Callsigns: make([]string, 0),
 	}
 	for _, friendly := range friendlies {


### PR DESCRIPTION
Removed the contact count and friendly count from MERGED calls. Since we update the merged states before broadcasting the  calls, the calls were sequentially communicating the same final merged state instead of the intermediate states, which was confusing.

Closes #340 