### PR TITLE
skip 'this is' when parsing callsigns

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -286,6 +286,7 @@ func ParsePilotCallsign(tx string) (callsign string, isValid bool) {
 	tx = normalize(tx)
 	tx = spaceDigits(tx)
 	tx = strings.ReplaceAll(tx, "request", "")
+	tx = strings.ReplaceAll(tx, "this is", "")
 
 	var builder strings.Builder
 	numDigits := 0

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -33,6 +33,7 @@ func TestParsePilotCallsign(t *testing.T) {
 		{"Red 243", "red 2 4 3"},
 		{"Red 054", "red 0 5 4"},
 		{"Gunfighter request", "gunfighter"},
+		{"This is Red 7", "red 7"},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
Fixes #345 