### PR TITLE
Deduplicate FADED calls

### DIFF
--- a/pkg/radar/started.go
+++ b/pkg/radar/started.go
@@ -1,10 +1,26 @@
 package radar
 
-import "github.com/rs/zerolog/log"
+import (
+	"time"
+
+	"github.com/dharmab/skyeye/pkg/sim"
+	"github.com/rs/zerolog/log"
+)
 
 func (r *Radar) handleStarted() {
 	log.Info().Msg("clearing all trackfiles due to mission (re)start")
 	r.contacts.reset()
+
+	log.Info().Msg("clearing pending FADED trackfiles due to mission (re)start")
+	r.pendingFadesLock.Lock()
+	defer r.pendingFadesLock.Unlock()
+	r.pendingFades = make([]sim.Faded, 0)
+
+	log.Info().Msg("clearing FADED trackfile history due to mission (re)start")
+	r.completedFadesLock.Lock()
+	defer r.completedFadesLock.Unlock()
+	r.completedFades = make(map[uint64]time.Time)
+
 	r.callbackLock.RLock()
 	defer r.callbackLock.RUnlock()
 	if r.startedCallback != nil {


### PR DESCRIPTION
Keep track of trackfile IDs that have faded in the last 5 minutes, and don't issue FADED calls for the same ID within that window.

Fixes #429 