### PR TITLE
Add support for OpenAI Transcription API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 SkyEye is a [Ground Controlled Intercept](https://en.wikipedia.org/wiki/Ground-controlled_interception) (GCI) bot for the flight simulator [Digital Combat Simulator](https://www.digitalcombatsimulator.com) (DCS). A GCI bot allows players to request information about the airspace in English using either voice commands or text entry, and to receive answers via verbal speech and text messages.
 
-SkyEye uses Speech-To-Text and Text-To-Speech technology which runs locally on the same computer as SkyEye. No cloud APIs are required. It works with any DCS mission, singleplayer or multiplayer. No special scripting or mission editor setup is required. You can run it for less than a nickel per hour on a cloud server, or run it on a PC in your home.
+SkyEye uses Speech-To-Text and Text-To-Speech technology which can run locally on the same computer as SkyEye. No cloud APIs are required, although cloud APIs are optionally supported. It works with any DCS mission, singleplayer or multiplayer. No special scripting or mission editor setup is required. You can run it for less than a nickel per hour on a cloud server, or run it on a PC in your home.
 
 SkyEye is production ready software. It is used by the [Flashpoint Levant](https://limakilo.net/) public server and a number of private squadrons.
 
@@ -20,7 +20,7 @@ SkyEye would not be possible without these people and projects, for whom I am de
 * [DCS-SRS](https://github.com/ciribob/DCS-SimpleRadioStandalone) by @ciribob. Ciribob also patiently answered many of my questions on SRS internals and provided helpful debugging tips whenever I ran into a block in the SRS integration.
 * [Tacview](https://www.tacview.net/) - specifically, [ACMI real time telemetry](https://www.tacview.net/documentation/realtime/en/) - provides the data feed from DCS World.
 * @rurounijones's [OverlordBot](https://gitlab.com/overlordbot) was a useful reference against SkyEye during early development, and Jones himself was also patient with my questions on Discord.
-* @ggerganov's [whisper.cpp](https://github.com/ggerganov/whisper.cpp) models provides speech-to-text.
+* OpenAI's [Whisper](https://github.com/openai/whisper) provides speech-to-text. @ggerganov's [whisper.cpp](https://github.com/ggerganov/whisper.cpp) allows Whisper to be used locally without requiring cloud services.
 * @rodaine's [numwords](https://github.com/rodaine/numwords) module is invaluable for parsing numeric quantities from voice input.
 * [Piper](https://github.com/rhasspy/piper) by the [Rhasspy](https://rhasspy.readthedocs.io/en/latest/) voice assistant project is used for speech-to-text.
 * The [Jenny dataset by Dioco](https://github.com/dioco-group/jenny-tts-dataset) provides the feminine voice for SkyEye.

--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,15 @@
 # Learn more: https://learnxinyminutes.com/docs/yaml/
 
 # SPEECH RECOGNITION
-# SkyEye requires a whisper.cpp model from
+#
+# Choose "openai-whisper-local" to use local speech recognition, which has
+# more intense system requirements.
+# Choose "openai-whisper-api" to use the OpenAI API for speech recognition,
+# which requires paying OpenAI for credits.
+# See docs/ADMIN.md for more details and advantages and disadvantages of each.
+#recognizer: openai-whisper-local
+#
+# If you chose local speech recogntion, SkyEye requires a whisper.cpp model from
 # https://huggingface.co/ggerganov/whisper.cpp/tree/main. Note that the
 # cloud-init and WinSW YAML files provided with the release will download the
 # model on your behalf before starting SkyEye. You probably only need to change
@@ -40,6 +48,10 @@
 # Only resort to the tiny model if the small model is too slow. It has poor
 # speech recognition quality.
 #whisper-model: ggml-tiny.en.bin
+#
+# If you chose the OpenAI API for cloud-based speech recognition, you need to
+# provide an API key. You can get an API key at https://openai.com/api.
+#openai-api-key: apikeygoeshere
 
 # TELEMETRY
 # Telemetry service address. Set this to the host and port of the TacView
@@ -85,7 +97,7 @@
 #grpc-address: dcs.example.com:50051
 #
 # If authentication is enabled on the DCS-gRPC server, set the API key here.
-# Authenication is STORNGLY RECOMMENDED if the DCS-gRPC server is exposed over
+# Authentication is STORNGLY RECOMMENDED if the DCS-gRPC server is exposed over
 # a network, as it allows powerful control over the DCS World server and mission.
 #grpc-password: passwordgoeshere
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -11,11 +11,15 @@ flowchart TD
     dcs[DCS World Server] -->|gameplay data| tacview[TacView Exporter]
     tacview -->|gameplay data| skyeye[SkyEye]
     srs[SRS Server] <-->|audio and radio data| skyeye
+    skyeye <-.->|audio data| openai["OpenAI Platform (optional)"]
     player[You] <-->|gameplay| dcs
     player <-->|voice| src[SRS Client]
     src <-->|audio and radio data| srs
 ```
 
+### Speech Recognition
+
+SkyEye may be configured using local
 
 ### Chat Integration
 
@@ -40,7 +44,6 @@ flowchart TD
     skyeye -->|transcriptions| discord[Discord]
 ```
 
-
 ## Your Data in SkyEye
 
 SkyEye connects to the SimpleRadio Standalone server (just like the official SRS-Client software) and a TacView real-time telemetry service (just like the official TacView client software). SkyEye has access to the same information these applications have, including:
@@ -51,9 +54,11 @@ SkyEye connects to the SimpleRadio Standalone server (just like the official SRS
 
 > Note: The "encryption" feature inside SRS is **not** an actual encryption system. It does not actually protect your voice audio from being read by other SRS clients.
 
-In order to function, SkyEye temporarily buffers audio data from SRS broadcast on the configured SkyEye frequencies. This audio data is discarded immediately after it is transcripted into text, usually within seconds. It is never saved to disk or to a database.
+In order to function, SkyEye temporarily buffers audio data from SRS broadcast on the configured SkyEye frequencies. SkyEye then uses either local speech recognition or cloud-based speech recognition to transcibe the audio into text. The server administrator chooses which form of speech recognition to use.
 
-If the in-game 
+If local speech recognition is used, the audio data is used as input to an AI model within SkyEye's internal memory. This audio data is discarded immediately after it is transcripted into text, usually within seconds. The audio is never saved to disk or to a database.
+
+If cloud-based speech recognition is used, the audio data sent over the Internet to the OpenAI Audio Transcription API. The data is sent over an encrypted connection. OpenAI's servers then perform the audio transcription and send the transcritpted text back to SkyEye over the same encrypted connection. Please read [OpenAI's Enterprise Privacy Policy](https://openai.com/enterprise-privacy/) for more information on how OpenAI handles data within their API.
 
 SkyEye outputs logs so server operators and developers can troubleshoot and improve SkyEye. The logs may be stored as long as the operator of the SkyEye server chooses to do so. These logs may include:
 
@@ -64,6 +69,6 @@ SkyEye outputs logs so server operators and developers can troubleshoot and impr
 
 SkyEye prioritizes speed over accuracy, so **the transcriptions are not accurate and may contain things that were not actually said.** For example, the codeword "Fox" is commonly mis-transcribed as "F**ks". [The speech recognition technology used is infamous for its inaccuracy](https://apnews.com/article/ai-artificial-intelligence-health-business-90020cdf5fa16c79ca2e5b6c4c9bbb14). SkyEye performs a great deal of post-processing of the transcriptions to best-guess at the player's intended selection from a limited set of commands; it is not a general-purpose dictation service. This software is not intended to be an accessibility tool for the hearing-impaired or a moderation tool. 
 
-The server operator may change the content of these logs using the `enable-transcription-logging` option. If this option is disabled, full text transcriptions are not logged. Small tokens of the text may still be logged if they are interpreted as part of a bot command. Transcriptions which do not seem to be directed at the bot will not be logged at all, and the full text of each message be excluded from the logs.
+The server operator may change the content of these logs using the `enable-transcription-logging` option. If this option is disabled, full text transcriptions are not logged. Small tokens of the text may still be logged if they are interpreted as part of a bot command. Transcriptions which do not seem to be directed at the bot will not be logged at all, and the full text of each message will be excluded from the logs.
 
 If the Discord integration is enabled, the transcriptions are also sent as messages to a Discord text channel along with some debugging data. The Discord server administrator may choose to make these messages visible to members of the Discord server. Please read the [Discord Terms of Service](https://discord.com/terms), [Discord Privacy Policy](https://discord.com/privacy), and [this article on data retention practices](https://support.discord.com/hc/en-us/articles/5431812448791-How-long-Discord-keeps-your-information) for more information on how Discord handles data.

--- a/docs/QUICKSTART-HETZNER.md
+++ b/docs/QUICKSTART-HETZNER.md
@@ -1,8 +1,12 @@
 # Quickstart on Hetzner Cloud
 
-This guide is a step-by-step on how to run SkyEye on [Hetzner Cloud](https://www.hetzner.com/clouod).
+This guide is a step-by-step on how to run SkyEye on [Hetzner Cloud](https://www.hetzner.com/cloud) using local speech recogntion.
 
 It is assumed that you have set up an account and a billing method.
+
+## Getting Help
+
+See [the admin guide](ADMIN.md#getting-help) for how to get help if you have a problem.
 
 ## Create a Firewall
 

--- a/docs/QUICKSTART-VULTR.md
+++ b/docs/QUICKSTART-VULTR.md
@@ -1,8 +1,12 @@
 # Quickstart on Vultr
 
-This guide is a step-by-step on how to run SkyEye on [Vultr](https://www.vultr.com/).
+This guide is a step-by-step on how to run SkyEye on [Vultr](https://www.vultr.com/) using local speech recogntion.
 
 It is assumed that you have set up an account, SSH keys and a billing method.
+
+## Getting Help
+
+See [the admin guide](ADMIN.md#getting-help) for how to get help if you have a problem.
 
 ## Create a SkyEye Server
 

--- a/docs/QUICKSTART-WINDOWS.md
+++ b/docs/QUICKSTART-WINDOWS.md
@@ -1,0 +1,73 @@
+# Simple Quickstart on Windows
+
+This guide is a step-by-step on how to run SkyEye on Windows alongside DCS, TacView and SRS Server using the OpenAI API for cloud speech recognition.
+
+## Getting Help
+
+See [the admin guide](ADMIN.md#getting-help) for how to get help if you have a problem.
+
+## Set up OpenAI API
+
+Go to https://platform.openai.com. If you haven't previously set up the OpenAI API, you'll go through a step-by-step process to set up an organization, buy credits, create a Project and generate an API key.
+
+Otherwise, go to https://platform.openai.com/settings/organization/api-keys and generate a new API key for SkyEye. I recommend adding this API key to a new Project named "SkyEye".
+
+Be sure to review the pricing of the "Whisper" audio model at https://openai.com/api/pricing. You will pay per-second for each second a player transmits on a SkyEye frequency in SRS. (You are not charged for the time SkyEye itself spends transmitting, nor are you charged for transmissions on other frequencies.)
+
+## Set Up DCS, Tacview, and SRS
+
+Install DCS (either the client for singleplayer/hosted multiplayer use, or a dedicated server for multiplayer use).
+
+Install the TacView Exporter. Within DCS, go to OPTIONS → SPECIAL → Tacview and enable Real-Time Telemetry.  (See https://www.tacview.net/documentation/dcs/en/)
+
+Install SRS. Start and configure the SRS Server.
+
+Makre sure DCS is running a mission with both friendly and hostile air units so you can do some tests.
+
+## Set up SkyEye
+
+Download the latest release of SkyEye from https://github.com/dharmab/skyeye/releases. (Click on the file `skyeye-windows-amd64.zip`).
+
+Extract the zip file somewhere convenient.
+
+Open `config.yaml` with a text editor (if you don't have one, download [Visual Studio Code](https://code.visualstudio.com). I don't recommend trying to edit YAML with Notepad because it's easy to make an indentation error.) Edit the file as required and save your changes.
+
+## Using SkyEye
+
+Open Windows Powershell and use the `cd` command to navigate to the folder containing `skyeye.exe`. (If you need help with this, ask ChatGPT how to do it.)
+
+Once you're in the correct folder, run the following command to install SkyEye.
+
+```powershell
+./skyeye-service.exe install
+```
+
+Next, run this command to start SkyEye:
+
+```powershell
+./skyeye-service.exe start
+```
+
+Confirm SkyEye is running using 
+
+```powershell
+./skyeye-service.exe status
+```
+
+Also, open the `skyeye-service.err.log` in Visual Studio Code. If you see a lot of repeated WARN or ERROR lines that don't go away, something may be wrong.
+
+Connect to your DCS game and SRS server. Switch to one of the SkyEye frequencies you configured. Try some test commands like a RADIO CHECK, ALPHA CHECK and PICTURE. (See the [player guide](PLAYER.md).)
+
+To stop SkyEye, run this command:
+
+```powershell
+./skyeye-service.exe stopwait
+```
+
+For instructions on:
+
+- Uninstalling SkyEye
+- Upgrading to a newer version of SkyEye
+- Automatically starting SkyEye on boot
+
+See [the full admin guide](ADMIN.md#windows).

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/lithammer/shortuuid/v3 v3.0.7
 	github.com/martinlindhe/unit v0.0.0-20230420213220-4adfd7d0a0d6
 	github.com/nabbl/piper v0.0.0-20240819160100-e51f2288a5c0
+	github.com/openai/openai-go v0.1.0-alpha.41
 	github.com/pasztorpisti/go-crc v1.0.0
 	github.com/paulmach/orb v0.11.1
 	github.com/proway2/go-igrf v0.5.1
@@ -193,6 +194,10 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tdakkota/asciicheck v0.2.0 // indirect
 	github.com/tetafro/godot v1.4.16 // indirect
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/timakin/bodyclose v0.0.0-20230421092635-574207250966 // indirect
 	github.com/timonwong/loggercheck v0.9.4 // indirect
 	github.com/tomarrell/wrapcheck/v2 v2.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -467,6 +467,8 @@ github.com/onsi/ginkgo/v2 v2.20.0 h1:PE84V2mHqoT1sglvHc8ZdQtPcwmvvt29WLEEO3xmdZw
 github.com/onsi/ginkgo/v2 v2.20.0/go.mod h1:lG9ey2Z29hR41WMVthyJBGUBcBhGOtoPF2VFMvBXFCI=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
+github.com/openai/openai-go v0.1.0-alpha.41 h1:OPRT5YfNKlENfipMtolMWnKbCR1iQDc9hCRsUkhMaK8=
+github.com/openai/openai-go v0.1.0-alpha.41/go.mod h1:3SdE6BffOX9HPEQv8IL/fi3LYZ5TUpRYaqGQZbyk11A=
 github.com/orcaman/writerseeker v0.0.0-20200621085525-1d3f536ff85e h1:s2RNOM/IGdY0Y6qfTeUKhDawdHDpK9RGBdx80qN4Ttw=
 github.com/orcaman/writerseeker v0.0.0-20200621085525-1d3f536ff85e/go.mod h1:nBdnFKj15wFbf94Rwfq4m30eAcyY9V/IyKAGQFtqkW0=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
@@ -620,7 +622,17 @@ github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpR
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tetafro/godot v1.4.16 h1:4ChfhveiNLk4NveAZ9Pu2AN8QZ2nkUGFuadM9lrr5D0=
 github.com/tetafro/godot v1.4.16/go.mod h1:2oVxTBSftRTh4+MVfUaUXR6bn2GDXCaMcOG4Dk3rfio=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/timakin/bodyclose v0.0.0-20230421092635-574207250966 h1:quvGphlmUVU+nhpFa4gg4yJyTRJ13reZMDHrKwYw53M=
 github.com/timakin/bodyclose v0.0.0-20230421092635-574207250966/go.mod h1:27bSVNWSBOHm+qRp1T9qzaIpsWEP6TbUnei/43HK+PQ=
 github.com/timonwong/loggercheck v0.9.4 h1:HKKhqrjcVj8sxL7K77beXh0adEm6DLjV/QOGeMXEVi4=

--- a/internal/application/app.go
+++ b/internal/application/app.go
@@ -146,7 +146,15 @@ func NewApplication(config conf.Configuration) (*Application, error) {
 	}
 
 	log.Info().Msg("constructing speech-to-text recognizer")
-	speechRecognizer := recognizer.NewWhisperRecognizer(config.WhisperModel, config.Callsign)
+	var speechRecognizer recognizer.Recognizer
+	switch config.Recognizer {
+	case conf.WhisperLocal:
+		speechRecognizer = recognizer.NewWhisperRecognizer(config.WhisperModel, config.Callsign)
+	case conf.WhisperAPI:
+		speechRecognizer = recognizer.NewOpenAIRecognizer(config.OpenAIAPIKey, config.Callsign)
+	default:
+		return nil, fmt.Errorf("failed to construct application: unrecognized recognizer %q", config.Recognizer)
+	}
 
 	log.Info().Msg("constructing request parser")
 	requestParser := parser.New(config.Callsign, config.EnableTranscriptionLogging)

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -10,6 +10,13 @@ import (
 	"github.com/martinlindhe/unit"
 )
 
+type Recognizer string
+
+const (
+	WhisperLocal Recognizer = "openai-whisper-local"
+	WhisperAPI   Recognizer = "openai-whisper-api"
+)
+
 // Configuration for the SkyEye application.
 type Configuration struct {
 	// ACMIFile is the path to the ACMI file
@@ -47,8 +54,12 @@ type Configuration struct {
 	// RadarSweepInterval is the rate at which the radar will update. This does not impact performance - ACMI data is still streamed at the same rate.
 	// It only impacts the update rate of the GCI radar picture.
 	RadarSweepInterval time.Duration
-	// WhisperModel is a whisper.cpp model used for Speech To Text
+	// Recognizer selects which speech-to-text recognizer to use.
+	Recognizer Recognizer
+	// WhisperModel is a whisper.cpp model used for Speech To Text. It may be nil if OpenAI API transcription is configured.
 	WhisperModel *whisper.Model
+	// OpenAIAPIKey is the API key for the OpenAI API. It may be empty if local transcription is configured.
+	OpenAIAPIKey string
 	// Voice is the voice used for SRS transmissions
 	Voice voices.Voice
 	// Mute disables SRS transmissions

--- a/pkg/recognizer/openai.go
+++ b/pkg/recognizer/openai.go
@@ -1,0 +1,134 @@
+package recognizer
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/dharmab/skyeye/pkg/pcm"
+	"github.com/rs/zerolog/log"
+
+	openai "github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+)
+
+type openaiRecognizer struct {
+	callsign string
+	client   *openai.Client
+}
+
+var _ Recognizer = &openaiRecognizer{}
+
+func NewOpenAIRecognizer(apiKey, callsign string) Recognizer {
+	return &openaiRecognizer{
+		callsign: callsign,
+		client: openai.NewClient(
+			option.WithAPIKey(apiKey),
+		),
+	}
+}
+
+type transcriptionResponse struct {
+	Text string `json:"text"`
+}
+
+func (r *openaiRecognizer) Recognize(ctx context.Context, sample []float32, _ bool) (string, error) {
+	buf, err := createWAV(sample)
+	if err != nil {
+		return "", fmt.Errorf("error creating WAV: %w", err)
+	}
+	body := openai.AudioTranscriptionNewParams{
+		File:     openai.FileParam(buf, "audio.wav", "audio/wav"),
+		Model:    openai.String("whisper-1"),
+		Language: openai.String("en"),
+		Prompt:   openai.String(prompt(r.callsign)),
+	}
+	log.Info().Msg("calling OpenAI Audio Transcriptions API")
+	transcription, err := r.client.Audio.Transcriptions.New(ctx, body)
+	if err != nil {
+		return "", fmt.Errorf("error transcribing audio: %w", err)
+	}
+	return transcription.Text, nil
+}
+
+func createWAV(sample []float32) (*bytes.Buffer, error) {
+	sampleRate := 16000
+	channels := 1
+	bitsPerSample := 16
+	bytesPerSample := bitsPerSample / 8
+	bytesPerBlock := channels * bitsPerSample / 8
+	bytesPerSecond := sampleRate * bytesPerBlock
+
+	data := pcm.F32toS16LE(sample)
+	dataSize := len(data) * bytesPerSample
+
+	buf := new(bytes.Buffer)
+	var writeErr error
+	_, err := buf.WriteString("RIFF")
+	if err != nil {
+		writeErr = errors.Join(writeErr, err)
+	}
+	// File size (placeholder for now)
+	if err := writeBinary(buf, int32(0)); err != nil {
+		writeErr = errors.Join(writeErr, err)
+	}
+	if _, err := buf.WriteString("WAVE"); err != nil {
+		writeErr = errors.Join(writeErr, err)
+	}
+	if _, err := buf.WriteString("fmt "); err != nil {
+		writeErr = errors.Join(writeErr, err)
+	}
+	// Remaining size of the fmt chunk = 16 bytes
+	if err := writeBinary(buf, int32(16)); err != nil {
+		writeErr = errors.Join(writeErr, err)
+	}
+	// Audio format (PCM integer=1)
+	if err := writeBinary(buf, int16(1)); err != nil {
+		writeErr = errors.Join(writeErr, err)
+	}
+	if err := writeBinary(buf, int16(channels)); err != nil {
+		writeErr = errors.Join(writeErr, err)
+	}
+	if err := writeBinary(buf, int32(sampleRate)); err != nil {
+		writeErr = errors.Join(writeErr, err)
+	}
+	if err := writeBinary(buf, int32(bytesPerSecond)); err != nil {
+		writeErr = errors.Join(writeErr, err)
+	}
+	if err := writeBinary(buf, int16(bytesPerBlock)); err != nil {
+		writeErr = errors.Join(writeErr, err)
+	}
+	if err := writeBinary(buf, int16(bitsPerSample)); err != nil {
+		writeErr = errors.Join(writeErr, err)
+	}
+	if _, err := buf.WriteString("data"); err != nil {
+		writeErr = errors.Join(writeErr, err)
+	}
+	if err := writeBinary(buf, int32(dataSize)); err != nil {
+		writeErr = errors.Join(writeErr, err)
+	}
+	for _, d := range data {
+		if err := writeBinary(buf, d); err != nil {
+			writeErr = errors.Join(writeErr, err)
+		}
+	}
+
+	// Update file size
+	fileSize := buf.Len() - 8
+	fileSizeBytes := new(bytes.Buffer)
+	if err := writeBinary(fileSizeBytes, int32(fileSize)); err != nil {
+		writeErr = errors.Join(writeErr, err)
+	}
+	copy(buf.Bytes()[4:8], fileSizeBytes.Bytes())
+
+	if writeErr != nil {
+		return nil, writeErr
+	}
+	return buf, nil
+}
+
+func writeBinary(w *bytes.Buffer, data interface{}) error {
+	return binary.Write(w, binary.LittleEndian, data)
+}

--- a/pkg/recognizer/prompt.go
+++ b/pkg/recognizer/prompt.go
@@ -1,0 +1,8 @@
+package recognizer
+
+import "fmt"
+
+// prompt is a prompt for OpenAI's Whisper model. See https://platform.openai.com/docs/guides/speech-to-text#prompting
+func prompt(callsign string) string {
+	return fmt.Sprintf("Either ANYFACE or %s, PILOT CALLSIGN, DIGITS, one of 'RADIO' 'ALPHA' 'BOGEY' 'PICTURE' 'DECLARE' 'SNAPLOCK' 'SPIKED', ARGUMENTS such as BULLSEYE, BRAA, numbers or digits.", callsign)
+}

--- a/pkg/recognizer/whisper.go
+++ b/pkg/recognizer/whisper.go
@@ -39,8 +39,8 @@ func (r *whisperRecognizer) Recognize(ctx context.Context, sample []float32, ena
 	if err != nil {
 		return "", fmt.Errorf("error creating whisper context: %w", err)
 	}
-	prompt := fmt.Sprintf("You receive commands in this template: \"Either ANYFACE or %s, PILOT CALLSIGN, DIGITS, one of 'RADIO' 'ALPHA' 'BOGEY' 'PICTURE' 'DECLARE' 'SNAPLOCK' 'SPIKED'\", ARGUMENTS. Parse numbers as digits. Separate numbers if there is silence between them. You may hear keywords in the arguments such as BULLSEYE or BRAA.", r.callsign)
-	wCtx.SetInitialPrompt(prompt)
+
+	wCtx.SetInitialPrompt(prompt(r.callsign))
 
 	if wCtx.IsMultilingual() {
 		_ = wCtx.SetLanguage("en")


### PR DESCRIPTION
Adds two new configuration flags, `--recognizer` and `--openai-api-key`, which together allow the use of [OpenAI's Audio Transcription API](https://platform.openai.com/docs/api-reference/audio/createTranscription).

Resolves #163 