### PR TITLE
Fix race conditions

### DIFF
--- a/pkg/controller/picture.go
+++ b/pkg/controller/picture.go
@@ -40,7 +40,11 @@ func (c *Controller) broadcastPicture(ctx context.Context, logger *zerolog.Logge
 		c.calls <- NewCall(ctx, brevity.PictureResponse{Count: count, Groups: groups})
 	}
 
-	c.pictureBroadcastDeadline = time.Now().Add(c.pictureBroadcastInterval)
+	func() {
+		c.pictureBroadcastDeadlineLock.Lock()
+		defer c.pictureBroadcastDeadlineLock.Unlock()
+		c.pictureBroadcastDeadline = time.Now().Add(c.pictureBroadcastInterval)
+	}()
 	c.wasLastPictureClean = isPictureClean
 	logger.Info().Time("deadline", c.pictureBroadcastDeadline).Msg("extended next PICTURE broadcast time")
 }

--- a/pkg/radar/radar.go
+++ b/pkg/radar/radar.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dharmab/skyeye/pkg/coalitions"
 	"github.com/dharmab/skyeye/pkg/encyclopedia"
 	"github.com/dharmab/skyeye/pkg/sim"
-	"github.com/dharmab/skyeye/pkg/spatial"
 	"github.com/dharmab/skyeye/pkg/trackfiles"
 	"github.com/martinlindhe/unit"
 	"github.com/paulmach/orb"
@@ -228,7 +227,7 @@ func (r *Radar) handleGarbageCollection() {
 //   - If AGL is known, AGL is above 10 meters
 //   - If AGL is unknown, speed is above 50 knots
 func isValidTrack(trackfile *trackfiles.Trackfile) bool {
-	if spatial.IsZero(trackfile.LastKnown().Point) {
+	if trackfile.IsLastKnownPointZero() {
 		return false
 	}
 

--- a/pkg/trackfiles/trackfile.go
+++ b/pkg/trackfiles/trackfile.go
@@ -108,6 +108,12 @@ func (t *Trackfile) Bullseye(bullseye orb.Point) brevity.Bullseye {
 func (t *Trackfile) LastKnown() Frame {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
+	return t.unsafeLastKnown()
+}
+
+// unsafeLastKnown is like LastKnown, but it does not acquire a lock. The calling
+// function must acquire t.lock before calling this function.
+func (t *Trackfile) unsafeLastKnown() Frame {
 	if t.track.Len() == 0 {
 		return Frame{}
 	}
@@ -121,7 +127,7 @@ func (t *Trackfile) IsLastKnownPointZero() bool {
 }
 
 func (t *Trackfile) bestAvailableDeclination() unit.Angle {
-	latest := t.LastKnown()
+	latest := t.unsafeLastKnown()
 	declincation, err := bearings.Declination(latest.Point, latest.Time)
 	if err != nil {
 		return 0


### PR DESCRIPTION
Fix two data races:

- Deadline to broadcast next picture was not protected and could be accessed from either the controller's ticker loop or the workload to handle a PICTURE request.
- Trackfile deque lock was acquired by LastKnown() and also functions which had LastKnown() in the call tree. Separated out an unsafe version of LastKnown() for internal use by those functions.

Fixes #522 