### PR TITLE
Install CA certificates in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN make skyeye-scaler
 
 FROM debian:bookworm-slim AS base
 RUN apt-get update && apt-get install -y \
+  ca-certificates \
   libopus0 \
   libsoxr0 \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Install CA certificates in the container image so requests can be made to OpenAI. This was missed because generally people using the OpenAI API are running SkyEye on Windows as an extra process on their DCS server.

This sadly will require a rebuild every so often to update the ca-certificates package, unless the user bind-mounts their OS certs into the container.

Fixes #575 