### PR TITLE
Fix Makefile for Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,9 @@ GO = /ucrt64/bin/go
 GOBUILDVARS += GOROOT="/ucrt64/lib/go" GOPATH="/ucrt64"
 # Static linking on Windows to avoid MSYS2 dependency at runtime
 LIBRARIES = opus soxr
-CFLAGS = $(pkg-config $(LIBRARIES) --cflags --static)
-BUILD_VARS += CFLAGS=$(CFLAGS)
-EXTLDFLAGS = $(pkg-config $(LIBRARIES) --libs --static)
+CFLAGS = $(shell pkg-config $(LIBRARIES) --cflags --static)
+BUILD_VARS += CFLAGS='$(CFLAGS)'
+EXTLDFLAGS = $(shell pkg-config $(LIBRARIES) --libs --static)
 LDFLAGS += -linkmode external -extldflags "$(EXTLDFLAGS) -static"
 endif
 


### PR DESCRIPTION
The `pkg-config` would evaluate to nothing and not the correct value - need the [shell prefix](https://www.gnu.org/software/make/manual/html_node/Setting.html) to expand to the command's result (see last paragraph).