### PR TITLE
Change SRS message and radio info struct serialization field names to camelCase

### DIFF
--- a/pkg/simpleradio/message.go
+++ b/pkg/simpleradio/message.go
@@ -31,7 +31,7 @@ func (c *Client) Send(message types.Message) error {
 // newMessage creates a new message with the client's version, the given message type, and the client's info.
 func (c *Client) newMessage(t types.MessageType) types.Message {
 	message := types.Message{
-		Version: "2.1.0.2", // stubbing fake SRS version, TODO add flag
+		Version: "2.3.2.1", // stubbing fake SRS version, TODO add flag
 		Type:    t,
 	}
 	message.Client = c.clientInfo

--- a/pkg/simpleradio/types/info.go
+++ b/pkg/simpleradio/types/info.go
@@ -9,19 +9,19 @@ import (
 // ClientInfo is information about the client included in messages.
 type ClientInfo struct {
 	// GUID a unique client ID.
-	GUID GUID `json:"ClientGuid"`
+	GUID GUID `json:"clientGuid"`
 	// Name is the name that will appear in the client list and in in-game transmissions
-	Name string `json:"Name"`
+	Name string `json:"name"`
 	// Seat is the seat number for multicrew aircraft. For bots, set this to 0.
-	Seat int `json:"Seat"`
+	Seat int `json:"seat"`
 	// Coalition is the side that the client will act on
-	Coalition coalitions.Coalition `json:"Coalition"`
+	Coalition coalitions.Coalition `json:"coalition"`
 	// AllowRecording indicates consent to record audio server-side. For bots, this should usually be set to True.
-	AllowRecording bool `json:"AllowRecord"`
+	AllowRecording bool `json:"allowRecord"`
 	// RadioInfo contains the client's unit, radios, transponder and ambient audio settings.
-	RadioInfo RadioInfo `json:"RadioInfo"`
+	RadioInfo RadioInfo `json:"radioInfo"`
 	// Position is the unit's in-game location. This is omitted for external clients not bound to a unit.
-	Position *Position `json:"LatLngPosition,omitempty"`
+	Position *Position `json:"latLngPosition,omitempty"`
 }
 
 // RadioInfo is information about a client's radios.

--- a/pkg/simpleradio/types/message.go
+++ b/pkg/simpleradio/types/message.go
@@ -19,15 +19,15 @@ const (
 // The order of fields in this type matches the order of fields in the official SRS client, just in case a different order were to trigger some obscure bug.
 type Message struct {
 	// Version is the SRS client version.
-	Version string `json:"Version"`
+	Version string `json:"version"`
 	// Client is used in messages that reference a single client.
-	Client ClientInfo `json:"Client"` // TODO v2: Change type to *ClientInfo and set omitempty
+	Client ClientInfo `json:"client"` // TODO v2: Change type to *ClientInfo and set omitempty
 	// Clients is used in messages that reference multiple clients.
-	Clients []ClientInfo `json:"Clients,omitempty"`
+	Clients []ClientInfo `json:"clients,omitempty"`
 	// ServerSettings is a map of server settings and their values. It sometimes appears in Sync messages.
-	ServerSettings map[string]string `json:"ServerSettings,omitempty"`
+	ServerSettings map[string]string `json:"serverSettings,omitempty"`
 	// ExternalAWACSModePassword is the External AWACS Mode password, used in ExternalAWACSModePassword messages to authenticate a client as an AWACS.
-	ExternalAWACSModePassword string `json:"ExternalAWACSModePassword,omitempty"`
+	ExternalAWACSModePassword string `json:"externalAWACSModePassword,omitempty"`
 	// Type is the type of the message.
-	Type MessageType `json:"MsgType"`
+	Type MessageType `json:"msgType"`
 }


### PR DESCRIPTION
```
[10:58] Thursday, 19 June 2025 10:58
gcask: Heads up: with a future release of srs, we will be switching from newsoft json to dotnet's implementation.

This gives us better, faster, stronger but also stricter parsing.
For anything user facing we'll keep it lenient, but for any client/server message passing it'll be tighter.

It matters if you wrote your own "client", where you might want to double check your properties are camelCase.

(thinking about @Zaid in particular here).

The performance of srs are already pretty good and they're about to get better. More cpu time for your dcs 

[17:17] Thursday, 19 June 2025 17:17
Zaid: @gcask I've got the ClientInfo and Message structs using PascalCase and everything else using camelCase:
https://github.com/dharmab/skyeye/blob/main/pkg/simpleradio/types/info.go
https://github.com/dharmab/skyeye/blob/main/pkg/simpleradio/types/message.go

Are those changing?

[17:29] Thursday, 19 June 2025 17:29
gcask: yes! They should work fine with either case for now, but they will move towards camelCase.

if you want to build/test locally, you can use this branch for now: https://github.com/gcask/DCS-SimpleRadioStandalone/tree/system-json (PR #777 if you want to check the diffs) (waiting for the current release to settle a bit before moving forward).

Well actually it's even trickier: for the net messages, I'm not specifying the casing so it should match the property name casing for the equivalent structs in the C# code.
```