### PR TITLE
Add v2-dev branch to CI triggers

### DIFF
--- a/.github/workflows/skyeye.yaml
+++ b/.github/workflows/skyeye.yaml
@@ -1,9 +1,9 @@
 name: SkyEye
 on:
   push:
-    branches: [main]
+    branches: [main, v2-dev]
   pull_request:
-    branches: [main]
+    branches: [main, v2-dev]
   release:
     types: [published]
 jobs:


### PR DESCRIPTION
## Summary
- Adds `v2-dev` to the `push` and `pull_request` branch lists in `.github/workflows/skyeye.yaml` so CI runs on pushes and PRs targeting `v2-dev`
- Release and push-images jobs are tag-gated and unaffected

## Test plan
- [ ] Verify the CI workflow triggers on this PR
- [ ] Confirm lint, test, and build jobs run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)