### PR TITLE
fix(simpleradio): use atomic.Bool for secureCoalitionRadios

### DIFF
--- a/pkg/simpleradio/client.go
+++ b/pkg/simpleradio/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dharmab/skyeye/pkg/simpleradio/types"
@@ -49,7 +50,9 @@ type Client struct {
 	clientsLock sync.RWMutex
 
 	// secureCoalitionRadios indicates if the client should only receive transmissions from the same coalition.
-	secureCoalitionRadios bool
+	// Written by the TCP receiver goroutine (updateServerSettings) and read by the UDP receiver
+	// goroutine (receive path); use atomic.Bool to avoid a data race.
+	secureCoalitionRadios atomic.Bool
 
 	// rxChan is a channel where received transmission are published. A read-only version is available publicly.
 	rxChan chan Transmission

--- a/pkg/simpleradio/message.go
+++ b/pkg/simpleradio/message.go
@@ -78,13 +78,13 @@ func (c *Client) updateServerSettings(message types.Message) {
 	log.Debug().Any("serverSettings", message.ServerSettings).Msg("received server settings")
 	if enabled, ok := message.ServerSettings[string(types.CoalitionAudioSecurity)]; ok {
 		if strings.ToLower(enabled) == "true" {
-			if !c.secureCoalitionRadios {
+			if !c.secureCoalitionRadios.Load() {
 				log.Info().Msg("enabling secure coalition radios")
 			}
-			c.secureCoalitionRadios = true
+			c.secureCoalitionRadios.Store(true)
 		} else {
 			log.Info().Msg("disabling secure coalition radios")
-			c.secureCoalitionRadios = false
+			c.secureCoalitionRadios.Store(false)
 		}
 	}
 	if enabled, ok := message.ServerSettings[string(types.ExternalAWACSMode)]; ok {

--- a/pkg/simpleradio/receive.go
+++ b/pkg/simpleradio/receive.go
@@ -104,7 +104,7 @@ func (c *Client) receiveVoice(ctx context.Context, in <-chan []byte, out chan<- 
 
 			logger := log.With().Str("GUID", string(packet.OriginGUID)).Logger()
 
-			if c.secureCoalitionRadios {
+			if c.secureCoalitionRadios.Load() {
 				client, ok := c.clients[types.GUID(packet.OriginGUID)]
 				if !ok {
 					logger.Warn().Msg("ignoring voice packet from unknown client")


### PR DESCRIPTION
Fixes dharmab/skyeye#661.

## Problem

`secureCoalitionRadios` was a plain `bool` written from the TCP receiver goroutine in `updateServerSettings` (`pkg/simpleradio/message.go:77-91`) and read from the UDP receiver goroutine (`pkg/simpleradio/receive.go:107`) with no synchronization. The Go race detector flagged it, and an unlucky interleaving could let a voice packet skip the coalition filter while the flag was flipping.

## Fix

Switch the field to `sync/atomic.Bool` and route the write/read through `Store`/`Load`. The one-shot "enabling secure coalition radios" transition log still fires only when the flag actually flips, via a `Load()` check before `Store(true)`.

## Test

`gofmt` clean. `go test -race` locally fails to link because the opus/opusfile system packages aren't installed on my machine, but the race was surfaced in CI on the linked issue and this is the minimal correctness fix.