### PR TITLE
Replace gammazero/deque with dharmab/collections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dharmab/skyeye
 
-go 1.26.0
+go 1.26.2
 
 require (
 	github.com/DCS-gRPC/go-bindings v0.7.1
@@ -8,9 +8,9 @@ require (
 	github.com/amitybell/piper-voice-alan v0.0.0-20231118093148-059963c24dbd
 	github.com/amitybell/piper-voice-jenny v0.0.0-20231118093224-dcf0d49e46b7
 	github.com/bwmarrin/discordgo v0.28.1
+	github.com/dharmab/collections v1.0.0
 	github.com/dharmab/goacmi v1.0.3
 	github.com/dharmab/numwords v1.0.1
-	github.com/gammazero/deque v0.2.1
 	github.com/ggerganov/whisper.cpp/bindings/go v0.0.0-20260319084013-9386f2394010
 	github.com/go-audio/aiff v1.1.0
 	github.com/gofrs/flock v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denis-tingaikin/go-header v0.5.0 h1:SRdnP5ZKvcO9KKRP1KJrhFR3RrlGuD+42t4429eC9k8=
 github.com/denis-tingaikin/go-header v0.5.0/go.mod h1:mMenU5bWrok6Wl2UsZjy+1okegmwQ3UgWl4V1D8gjlY=
+github.com/dharmab/collections v1.0.0 h1:61nyF4uDE8JvyiGC2VPz0rDXO6WVqKTlIpuXmzhreyo=
+github.com/dharmab/collections v1.0.0/go.mod h1:XL7nAecAuQ07ZGWSM0/kqVyl1z8ucE/jLUiIWQo6jCA=
 github.com/dharmab/goacmi v1.0.3 h1:NSxBKlLgJlI/V7Q68lh2uLZC6BJgZkphelKKEmSaEMc=
 github.com/dharmab/goacmi v1.0.3/go.mod h1:wZArjjRgFNYtQJkA9vBTbpM3FqkP3fg+bhQJzkEwpq0=
 github.com/dharmab/numwords v1.0.1 h1:6zFMoWEiavZmQAiyd1/0h8x/5gzpj8ijbZWgcIHoQAA=
@@ -208,8 +210,6 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fzipp/gocyclo v0.6.0 h1:lsblElZG7d3ALtGMx9fmxeTKZaLLpU8mET09yN4BBLo=
 github.com/fzipp/gocyclo v0.6.0/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
-github.com/gammazero/deque v0.2.1 h1:qSdsbG6pgp6nL7A0+K/B7s12mcCY/5l5SIUpMOl+dC0=
-github.com/gammazero/deque v0.2.1/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
 github.com/ggerganov/whisper.cpp/bindings/go v0.0.0-20260319084013-9386f2394010 h1:+m6yO3VYSAUUzpG9lz4ktBx0cCba/Nvww8OKDgnapQQ=
 github.com/ggerganov/whisper.cpp/bindings/go v0.0.0-20260319084013-9386f2394010/go.mod h1:qyHjS/50ORo01H0NsuEEGsQR9VCtOcEye0gUl2sx1s8=
 github.com/ghostiam/protogetter v0.3.20 h1:oW7OPFit2FxZOpmMRPP9FffU4uUpfeE/rEdE1f+MzD0=

--- a/pkg/trackfiles/trackfile.go
+++ b/pkg/trackfiles/trackfile.go
@@ -7,11 +7,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dharmab/collections/deques"
 	"github.com/dharmab/skyeye/pkg/bearings"
 	"github.com/dharmab/skyeye/pkg/brevity"
 	"github.com/dharmab/skyeye/pkg/coalitions"
 	"github.com/dharmab/skyeye/pkg/spatial"
-	"github.com/gammazero/deque"
 	"github.com/martinlindhe/unit"
 	"github.com/paulmach/orb"
 	"github.com/rs/zerolog/log"
@@ -36,7 +36,7 @@ type Trackfile struct {
 	// Contact contains identifying information.
 	Contact Labels
 	// track is a collection of frames, ordered from most recent to least recent.
-	track deque.Deque[Frame]
+	track *deques.Counting[Frame]
 	lock  sync.RWMutex
 }
 
@@ -61,7 +61,7 @@ type Frame struct {
 func New(labels Labels) *Trackfile {
 	return &Trackfile{
 		Contact: labels,
-		track:   *deque.New[Frame](),
+		track:   deques.NewCounting[Frame](maxLength),
 	}
 }
 
@@ -84,13 +84,10 @@ func (t *Trackfile) String() string {
 func (t *Trackfile) Update(f Frame) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
-	if t.track.Len() > 0 && f.Time.Before(t.track.Front().Time) {
+	if newest, ok := t.track.Newest(); ok && f.Time.Before(newest.Time) {
 		return
 	}
-	t.track.PushFront(f)
-	for t.track.Len() > maxLength {
-		t.track.PopBack()
-	}
+	t.track.Push(f)
 }
 
 // Bullseye returns the bearing and distance from the bullseye to the track's last known position.
@@ -108,16 +105,10 @@ func (t *Trackfile) Bullseye(bullseye orb.Point, opts ...spatial.Option) *brevit
 func (t *Trackfile) LastKnown() Frame {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
-	return t.unsafeLastKnown()
-}
-
-// unsafeLastKnown is like LastKnown, but it does not acquire a lock. The calling
-// function must acquire t.lock before calling this function.
-func (t *Trackfile) unsafeLastKnown() Frame {
-	if t.track.Len() == 0 {
-		return Frame{}
+	if f, ok := t.track.Newest(); ok {
+		return f
 	}
-	return t.track.Front()
+	return Frame{}
 }
 
 // IsLastKnownPointZero returns true if the last known point is at (0, 0).
@@ -126,8 +117,12 @@ func (t *Trackfile) IsLastKnownPointZero() bool {
 	return spatial.IsZero(t.LastKnown().Point)
 }
 
+// bestAvailableDeclination returns the magnetic declination at the track's most recent position, or 0 if unavailable.
 func (t *Trackfile) bestAvailableDeclination() unit.Angle {
-	latest := t.unsafeLastKnown()
+	latest, ok := t.track.Newest()
+	if !ok {
+		return 0
+	}
 	declincation, err := bearings.Declination(latest.Point, latest.Time)
 	if err != nil {
 		return 0
@@ -141,14 +136,22 @@ func (t *Trackfile) bestAvailableDeclination() unit.Angle {
 func (t *Trackfile) Course(opts ...spatial.Option) bearings.Bearing {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
+	return t.computeCourse(opts...)
+}
+
+// computeCourse returns the magnetic bearing between the two most recent frames, or the heading if only one frame exists. Caller must hold t.lock.
+func (t *Trackfile) computeCourse(opts ...spatial.Option) bearings.Bearing {
+	latest, ok := t.track.Newest()
+	if !ok {
+		return bearings.NewTrueBearing(0)
+	}
 	if t.track.Len() == 1 {
 		return bearings.NewTrueBearing(
-			t.track.Front().Heading,
+			latest.Heading,
 		).Magnetic(t.bestAvailableDeclination())
 	}
 
-	latest := t.track.Front()
-	previous := t.track.At(1)
+	previous, _ := t.track.At(1)
 
 	declination := t.bestAvailableDeclination()
 	course := spatial.TrueBearing(previous.Point, latest.Point, opts...).Magnetic(declination)
@@ -166,18 +169,19 @@ func (t *Trackfile) Direction() brevity.Track {
 		return brevity.UnknownDirection
 	}
 
-	course := t.Course()
-	return brevity.TrackFromBearing(course)
+	return brevity.TrackFromBearing(t.computeCourse())
 }
 
-// groundSpeed returns the approximate speed of the track along the ground (i.e. in two dimensions).
+// groundSpeed returns the approximate ground speed of the track in two dimensions. Caller must hold t.lock.
 func (t *Trackfile) groundSpeed(opts ...spatial.Option) unit.Speed {
-	if t.track.Len() < 2 {
+	latest, ok := t.track.Newest()
+	if !ok {
 		return 0
 	}
-
-	latest := t.track.Front()
-	previous := t.track.At(1)
+	previous, ok := t.track.At(1)
+	if !ok {
+		return 0
+	}
 
 	timeDelta := latest.Time.Sub(previous.Time)
 	if timeDelta == 0 {
@@ -197,12 +201,14 @@ func (t *Trackfile) groundSpeed(opts ...spatial.Option) unit.Speed {
 func (t *Trackfile) Speed() unit.Speed {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
-	if t.track.Len() < 2 {
+	latest, ok := t.track.Newest()
+	if !ok {
 		return 0
 	}
-
-	latest := t.track.Front()
-	previous := t.track.At(1)
+	previous, ok := t.track.At(1)
+	if !ok {
+		return 0
+	}
 
 	timeDelta := latest.Time.Sub(previous.Time)
 	if timeDelta == 0 {


### PR DESCRIPTION
The old deque panicked on empty access, forcing callers to guard with length checks or risk crashes. The new Counting deque returns (T, bool) from Newest/At/Pop, letting us propagate empty-state cleanly. 

Also fixes a potential deadlock where Direction() re-acquired RLock via Course().