### PR TITLE
Use stdlib slices package in nearby.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.11.1
 	github.com/zaf/resample v1.5.0
-	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b
 	golang.org/x/sys v0.41.0
 	google.golang.org/grpc v1.79.3
 	gopkg.in/hraban/opus.v2 v2.0.0-20230925203106-0188a62cb302
@@ -245,6 +244,7 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
+	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.51.0 // indirect

--- a/pkg/radar/nearby.go
+++ b/pkg/radar/nearby.go
@@ -2,6 +2,7 @@ package radar
 
 import (
 	"cmp"
+	"slices"
 
 	"github.com/dharmab/collections/sets"
 	"github.com/dharmab/skyeye/pkg/brevity"
@@ -10,7 +11,6 @@ import (
 	"github.com/martinlindhe/unit"
 	"github.com/paulmach/orb"
 	"github.com/paulmach/orb/geo"
-	"golang.org/x/exp/slices"
 )
 
 func (r *Radar) findNearbyGroups(pointOfInterest orb.Point, minAltitude, maxAltitude, radius unit.Length, coalition coalitions.Coalition, filter brevity.ContactCategory, excludedIDs []uint64) []*group {


### PR DESCRIPTION
Replace `golang.org/x/exp/slices` with the stdlib `slices` package in `pkg/radar/nearby.go`, and demote `golang.org/x/exp` to an indirect dependency via `go mod tidy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)