### PR TITLE
Bump GitHub Actions to clear Node.js 20 deprecation

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go.mod'
     - name: Install dependencies

--- a/.github/workflows/skyeye.yaml
+++ b/.github/workflows/skyeye.yaml
@@ -73,7 +73,7 @@ jobs:
           tar -czf dist/skyeye-linux-amd64.tar.gz -C dist skyeye-linux-amd64
       - name: Upload artifact
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: skyeye-linux-amd64.tar.gz
           path: dist/skyeye-linux-amd64.tar.gz
@@ -114,7 +114,7 @@ jobs:
           tar -czf dist/skyeye-macos-arm64.tar.gz -C dist skyeye-macos-arm64
       - name: Upload artifact
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: skyeye-macos-arm64.tar.gz
           path: dist/skyeye-macos-arm64.tar.gz
@@ -176,7 +176,7 @@ jobs:
           zip -r skyeye-windows-amd64.zip skyeye-windows-amd64
       - name: Upload artifact
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: skyeye-windows-amd64.zip
           path: dist/skyeye-windows-amd64.zip
@@ -212,7 +212,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: skyeye-*
           path: dist


### PR DESCRIPTION
## Summary

- `actions/setup-go` v5 → v6
- `actions/upload-artifact` v4 → v5
- `actions/download-artifact` v4 → v5

Each new major migrates the action runtime from Node.js 20 to Node.js 24, clearing the deprecation annotation ahead of the [June 16, 2026 forced-migration deadline](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). No workflow input changes were required.

## Test plan

- [ ] CI passes on this PR (lint, test, build-linux-amd64, build-macos-arm64, build-windows-amd64)
- [ ] No Node.js 20 deprecation annotation appears in the Actions run

🤖 Generated with [Claude Code](https://claude.com/claude-code)