### PR TITLE
Exclude piper speaker from macOS builds

### DIFF
--- a/pkg/synthesizer/speakers/piper.go
+++ b/pkg/synthesizer/speakers/piper.go
@@ -1,3 +1,5 @@
+//go:build !darwin
+
 package speakers
 
 import (

--- a/pkg/synthesizer/speakers/piper_darwin.go
+++ b/pkg/synthesizer/speakers/piper_darwin.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package speakers
+
+import (
+	"time"
+
+	"github.com/dharmab/skyeye/pkg/synthesizer/voices"
+)
+
+func NewPiperSpeaker(_ voices.Voice, _ float64, _ time.Duration) (Speaker, error) {
+	panic("unreachable: piper is not used on macOS")
+}


### PR DESCRIPTION
## Summary

- Adds `//go:build !darwin` to `pkg/synthesizer/speakers/piper.go` so the piper speaker and its embedded voice assets are not compiled into macOS binaries
- Adds `pkg/synthesizer/speakers/piper_darwin.go` — a minimal stub that satisfies the compiler without importing piper dependencies
- Reduces the macOS ARM64 binary from **159 MB → 29 MB** (82% smaller)

On macOS, `internal/application/app.go` always selects `NewMacOSSpeaker` at runtime; piper code was dead weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)