### PR TITLE
Fix --mute flag being ignored

### DIFF
--- a/internal/application/app.go
+++ b/internal/application/app.go
@@ -134,6 +134,7 @@ func NewApplication(config conf.Configuration) (*Application, error) {
 		ExternalAWACSModePassword: config.SRSExternalAWACSModePassword,
 		Coalition:                 config.Coalition,
 		Radios:                    radios,
+		Mute:                      config.Mute,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct application: %w", err)


### PR DESCRIPTION
## Context

Split off from #712, which found this while working in the same area.

`cmd/skyeye/main.go` sets `conf.Configuration.Mute` from the `--mute` flag, but `internal/application/app.go` never passed it into `srs.ClientConfiguration` when constructing the SRS client. The field already existed on `ClientConfiguration` - it just wasn't wired up, so the flag was a silent no-op.

## Fix

Pass `config.Mute` through in `NewApplication`.

## Testing

```
make vet
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)