### PR TITLE
Fix RadioFrequency string formatting

### DIFF
--- a/pkg/simpleradio/frequency.go
+++ b/pkg/simpleradio/frequency.go
@@ -75,7 +75,7 @@ func (f RadioFrequency) String() string {
 		suffix = "AM"
 	}
 
-	return fmt.Sprintf("%f.3%s", f.Frequency, suffix)
+	return fmt.Sprintf("%.3f%s", f.Frequency.Megahertz(), suffix)
 }
 
 // Frequencies returns the frequencies the client is listening on.

--- a/pkg/simpleradio/frequency_test.go
+++ b/pkg/simpleradio/frequency_test.go
@@ -50,3 +50,29 @@ func TestParseFrequency(t *testing.T) {
 		})
 	}
 }
+
+func TestRadioFrequencyString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		frequency RadioFrequency
+		expected  string
+	}{
+		{RadioFrequency{30 * unit.Megahertz, types.ModulationFM}, "30.000FM"},
+		{RadioFrequency{44.5 * unit.Megahertz, types.ModulationFM}, "44.500FM"},
+		{RadioFrequency{87.975 * unit.Megahertz, types.ModulationFM}, "87.975FM"},
+		{RadioFrequency{116 * unit.Megahertz, types.ModulationAM}, "116.000AM"},
+		{RadioFrequency{133.5 * unit.Megahertz, types.ModulationAM}, "133.500AM"},
+		{RadioFrequency{151.975 * unit.Megahertz, types.ModulationAM}, "151.975AM"},
+		{RadioFrequency{225 * unit.Megahertz, types.ModulationAM}, "225.000AM"},
+		{RadioFrequency{251 * unit.Megahertz, types.ModulationAM}, "251.000AM"},
+		{RadioFrequency{251.075 * unit.Megahertz, types.ModulationAM}, "251.075AM"},
+		{RadioFrequency{399.975 * unit.Megahertz, types.ModulationAM}, "399.975AM"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.expected, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.expected, test.frequency.String())
+		})
+	}
+}


### PR DESCRIPTION
## Context

Split off from #712, which found this while working in the same area.

`RadioFrequency.String()` had a transposed format verb (`"%f.3%s"`) and formatted the frequency in hertz rather than megahertz, so 251MHz AM rendered as `"251000000.000000.3AM"` instead of `"251.000AM"`. `go vet` doesn't catch it because `%f` is a valid verb for a `float64` and `.3` reads as literal text.

Nothing calls `String()` today, so this is latent rather than user-visible.

## Fix

`fmt.Sprintf("%.3f%s", f.Frequency.Megahertz(), suffix)`, plus a regression test.

## Testing

```
make vet
go test ./pkg/simpleradio/... -run TestRadioFrequencyString -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)