### PR TITLE
Run tests with -race by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,9 +243,8 @@ run:
 	$(BUILD_VARS) $(GO) run -race $(BUILD_FLAGS) ./cmd/skyeye/ $(ARGS)
 
 .PHONY: test
-TEST_FLAGS ?= -race
 test: generate
-	$(BUILD_VARS) $(GO) tool gotestsum -- $(BUILD_FLAGS) $(TEST_FLAGS) ./...
+	$(BUILD_VARS) $(GO) tool gotestsum -- $(BUILD_FLAGS) -race $(TEST_FLAGS) ./...
 
 .PHONY: benchmark-whisper
 benchmark-whisper: whisper

--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,7 @@ run:
 	$(BUILD_VARS) $(GO) run -race $(BUILD_FLAGS) ./cmd/skyeye/ $(ARGS)
 
 .PHONY: test
+TEST_FLAGS ?= -race
 test: generate
 	$(BUILD_VARS) $(GO) tool gotestsum -- $(BUILD_FLAGS) $(TEST_FLAGS) ./...
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -170,7 +170,7 @@ Wow, that was easy!
 
 ## Test
 
-The canonical way to run the unit tests is by running `make test`. This can run tests for code that uses CGO. **This is the gate used for PR checks.** Tests run with `-race` by default to catch data races. You can override the flags passed to `go test` using TEST_FLAGS. For example, `TEST_FLAGS="-race -parallel=1" make test` will run the tests without parallelism (1 test worker), which can make the logs for a failed test easier to understand.
+The canonical way to run the unit tests is by running `make test`. This can run tests for code that uses CGO. **This is the gate used for PR checks.** You can pass additional flags to `go test` using TEST_FLAGS. For example, `TEST_FLAGS=-parallel=1 make test` will run the tests without parallelism (1 test worker), which can make the logs for a failed test easier to understand.
 
 I have made an effort to structure packages so that CGO is never imported directly or indirectly within packages that aren't directly related to the Speech-To-Text and Text-To-Speech models. This means that most tests can be run through Visual Studio Code without the complexity and performance hit of CGO. **This is the easiest way to test and debug during development.**
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -170,7 +170,7 @@ Wow, that was easy!
 
 ## Test
 
-The canonical way to run the unit tests is by running `make test`. This can run tests for code that uses CGO. **This is the gate used for PR checks.** You can pass additional flags to `go test` using TEST_FLAGS. For example, `TEST_FLAGS=-parallel=1 make test` will run the tests without parallelism (1 test worker), which can make the logs for a failed test easier to understand.
+The canonical way to run the unit tests is by running `make test`. This can run tests for code that uses CGO. **This is the gate used for PR checks.** Tests run with `-race` by default to catch data races. You can override the flags passed to `go test` using TEST_FLAGS. For example, `TEST_FLAGS="-race -parallel=1" make test` will run the tests without parallelism (1 test worker), which can make the logs for a failed test easier to understand.
 
 I have made an effort to structure packages so that CGO is never imported directly or indirectly within packages that aren't directly related to the Speech-To-Text and Text-To-Speech models. This means that most tests can be run through Visual Studio Code without the complexity and performance hit of CGO. **This is the easiest way to test and debug during development.**
 


### PR DESCRIPTION
## Summary
- `make test` now runs with `-race` by default via `TEST_FLAGS ?= -race`, catching data races in CI
- `TEST_FLAGS` still overrides the default for cases like `TEST_FLAGS="-race -parallel=1" make test`

## Test plan
- [x] `make test` (full suite, 1154 tests) passes with `-race`, no data races detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)